### PR TITLE
Change build status badge hostname to jenkins.juliogonzalez.es

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The current version does not yet support WHERE clause push-down, column push-dow
 
 ## Build Status
 
-[![Build Status](https://jenkins-juliogonzalez.rhcloud.com/job/tds_fdw-build/badge/icon)](https://jenkins-juliogonzalez.rhcloud.com/job/tds_fdw-build/)
+[![Build Status](https://jenkins.juliogonzalez.es/job/tds_fdw-build/badge/icon)](https://jenkins.juliogonzalez.es/job/tds_fdw-build/)
 
 ## Installing on CentOS
 


### PR DESCRIPTION
Some months ago I changed the main hostname for Jenkins to jenkins.juliogonzalez.es, so it's easier to migrate it outside OpenShift at some point (if needed) without breaking all the associated projects.

For tds_fdw this is the first step (next will be to change the hooks).