### PR TITLE
Add test properties, including versioning

### DIFF
--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -1,38 +1,93 @@
 from glob import glob
+from json import load
 from messages import print_error, print_info
+from os.path import basename
 
 
-def run_tests(path, conn, replaces):
+def version_to_array(version, dbtype):
+    """ Convert a version string to a version array, or return an empty string if
+        the original string was empty
+
+    Keyword arguments:
+    version -- A string with a dot separated version
+    dbtype  -- A string with the database type (postgresql|mssql)
+    """
+    if version != '':
+        version = version.split('.')
+        for i in range(0, len(version)):
+            version[i] = int(version[i])
+    # To be able to work with MSSQL 2000 and 7.0,
+    # see https://sqlserverbuilds.blogspot.ru/
+    if dbtype == 'mssql':
+        if len(version) == 3:
+            version.append(0)
+    return(version)
+
+
+def check_ver(conn, min_ver, max_ver, dbtype):
+    """ Check SQL server version against test required max and min versions.
+
+    Keyword arguments:
+    conn    -- A db connection (according to Python DB API v2.0)
+    min_ver -- A string with the minimum version required
+    max_ver -- A string with the maximum version required
+    dbtype  -- A string with the database type (postgresql|mssql)
+    """
+    cursor = conn.cursor()
+    if dbtype == 'postgresql':
+        sentence = 'SELECT setting FROM pg_settings WHERE name = \'server_version\';'
+    elif dbtype == 'mssql':
+        sentence = 'SELECT serverproperty(\'ProductVersion\');'
+    cursor.execute(sentence)
+    server_ver = cursor.fetchone()[0]
+    cursor.close()
+    min_ver = version_to_array(min_ver, dbtype)
+    max_ver = version_to_array(max_ver, dbtype)
+    server_ver = version_to_array(server_ver, dbtype)
+    if server_ver >= min_ver and (server_ver <= max_ver or min_ver == ''):
+        return(True)
+    else:
+        return(False)
+
+
+def run_tests(path, conn, replaces, dbtype):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:
     path     -- String with the path having the SQL files for tests
     conn     -- A db connection (according to Python DB API v2.0)
     replaces -- A dict with replaces to perform at testing code
+    dbtype   -- A string with the database type (postgresql|mssql)
     """
     files = sorted(glob(path))
     tests = {'total': 0, 'ok': 0, 'errors': 0}
-    for file in files:
-        tests['total'] += 1
-        f = open(file, 'r')
-        sentence = f.read()
-        for key, elem in replaces.items():
-            sentence = sentence.replace(key, elem)
-        print_info("Running %s" % file)
-        try:
-            cursor = conn.cursor()
-            cursor.execute(sentence)
-            conn.commit()
-            cursor.close()
-            tests['ok'] += 1
-        except Exception as e:
-            print_error("Error running test %s" % file)
+    for fname in files:
+        test_file = open('%s.json' % fname.rsplit('.', 1)[0], 'r')
+        test_properties = load(test_file)
+        test_desc = test_properties['test_desc']
+        test_number = basename(fname).split('_')[0]
+        req_ver = test_properties['server']['version']
+        if check_ver(conn, req_ver['min'], req_ver['max'], dbtype):
+            tests['total'] += 1
+            f = open(fname, 'r')
+            sentence = f.read()
+            for key, elem in replaces.items():
+                sentence = sentence.replace(key, elem)
+            print_info("%s: Testing %s" % (test_number, test_desc))
             try:
-                print_error(e.pgcode)
-                print_error(e.pgerror)
-            except:
-                print_error(e)
-            conn.rollback()
-            tests['errors'] += 1
-        f.close()
+                cursor = conn.cursor()
+                cursor.execute(sentence)
+                conn.commit()
+                cursor.close()
+                tests['ok'] += 1
+            except Exception as e:
+                print_error("Error running %s (%s)" % (test_desc, fname))
+                try:
+                    print_error(e.pgcode)
+                    print_error(e.pgerror)
+                except:
+                    print_error(e)
+                conn.rollback()
+                tests['errors'] += 1
+            f.close()
     return(tests)

--- a/tests/mssql-tests.py
+++ b/tests/mssql-tests.py
@@ -60,7 +60,7 @@ def main():
                        password=args.password, database=args.database,
                        port=args.port)
         replaces = {'@SCHEMANAME': args.schema}
-        tests = run_tests('tests/mssql/*.sql', conn, replaces)
+        tests = run_tests('tests/mssql/*.sql', conn, replaces, 'mssql')
         print_report(tests['total'], tests['ok'], tests['errors'])
         if tests['errors'] != 0:
             exit(5)

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -86,7 +86,7 @@ def main():
                     '@MPASSWORD': args.mssql_password,
                     '@MDATABASE': args.mssql_database,
                     '@MSCHEMANAME': args.mssql_schema}
-        tests = run_tests('tests/postgresql/*.sql', conn, replaces)
+        tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql')
         print_report(tests['total'], tests['ok'], tests['errors'])
         if tests['errors'] != 0:
             exit(5)

--- a/tests/tests/mssql/000_create_schema.json
+++ b/tests/tests/mssql/000_create_schema.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "schema creation",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/001_create_tinyint_min_table.json
+++ b/tests/tests/mssql/001_create_tinyint_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with tinyint, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/002_create_tinyint_max_table.json
+++ b/tests/tests/mssql/002_create_tinyint_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with tinyint, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/003_create_smallint_min_table.json
+++ b/tests/tests/mssql/003_create_smallint_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with smallint, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/004_create_smallint_max_table.json
+++ b/tests/tests/mssql/004_create_smallint_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with smallint, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/005_create_int_min_table.json
+++ b/tests/tests/mssql/005_create_int_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with int, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/006_create_int_max_table.json
+++ b/tests/tests/mssql/006_create_int_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with int, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/007_create_bigint_min_table.json
+++ b/tests/tests/mssql/007_create_bigint_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with bigint, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/008_create_bigint_max_table.json
+++ b/tests/tests/mssql/008_create_bigint_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with bigint, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/009_create_decimal_table.json
+++ b/tests/tests/mssql/009_create_decimal_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with decimal data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/010_create_float4_table.json
+++ b/tests/tests/mssql/010_create_float4_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with float data type, 4 bytes size",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/011_create_float8_table.json
+++ b/tests/tests/mssql/011_create_float8_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with float data type, 8 bytes value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/012_create_date_table.json
+++ b/tests/tests/mssql/012_create_date_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with date data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/013_create_time_table.json
+++ b/tests/tests/mssql/013_create_time_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with time data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/014_create_datetime_table.json
+++ b/tests/tests/mssql/014_create_datetime_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with datetime data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/015_create_datetime2_table.json
+++ b/tests/tests/mssql/015_create_datetime2_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with datetime2 data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/016_create_datetimeoffset_table.json
+++ b/tests/tests/mssql/016_create_datetimeoffset_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with datetimeoffset data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/017_create_char_table.json
+++ b/tests/tests/mssql/017_create_char_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with char data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/018_create_varchar_table.json
+++ b/tests/tests/mssql/018_create_varchar_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with varchar data type",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/019_create_varcharmax_table.json
+++ b/tests/tests/mssql/019_create_varcharmax_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with varchar data type, maximum length",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/020_create_binary4_table.json
+++ b/tests/tests/mssql/020_create_binary4_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with binary data type, 4 bytes length",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/021_create_varbinary4_table.json
+++ b/tests/tests/mssql/021_create_varbinary4_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with varbinary data type, 4 bytes length",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/022_create_varbinarymax_table.json
+++ b/tests/tests/mssql/022_create_varbinarymax_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with varbinary data type, maximum size",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/023_create_null_datetime_table.json
+++ b/tests/tests/mssql/023_create_null_datetime_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with datetime data type, null value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/024_create_null_datetime2_table.json
+++ b/tests/tests/mssql/024_create_null_datetime2_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with datetime2 data type, null value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/025_create_match_column_table.json
+++ b/tests/tests/mssql/025_create_match_column_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation for automated column matching",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/026_create_column_name_table.json
+++ b/tests/tests/mssql/026_create_column_name_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation for column name manual matching",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/027_create_query_option_table.json
+++ b/tests/tests/mssql/027_create_query_option_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation for automated column matching (query option)",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/000_create_schema.json
+++ b/tests/tests/postgresql/000_create_schema.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "schema creation",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/001_create_server.json
+++ b/tests/tests/postgresql/001_create_server.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "foreign server creation",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/002_create_user_mapping.json
+++ b/tests/tests/postgresql/002_create_user_mapping.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "user mapping creation",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/003_tinyintmin.json
+++ b/tests/tests/postgresql/003_tinyintmin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "tinyint data type, minimum value (smallint)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/004_tinyintmax.json
+++ b/tests/tests/postgresql/004_tinyintmax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "tinyint data type, maximum value (smallint)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/005_smallintmin.json
+++ b/tests/tests/postgresql/005_smallintmin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "smallint data type, minimum value (smallint)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/006_smallintmax.json
+++ b/tests/tests/postgresql/006_smallintmax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "smallint data type, maximum value (smallint)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/007_intmin.json
+++ b/tests/tests/postgresql/007_intmin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "int data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/008_intmax.json
+++ b/tests/tests/postgresql/008_intmax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "int data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/009_bigintmin.json
+++ b/tests/tests/postgresql/009_bigintmin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "bigint data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/010_bigintmax.json
+++ b/tests/tests/postgresql/010_bigintmax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "bigint data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/011_decimal.json
+++ b/tests/tests/postgresql/011_decimal.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "decimal data type (numeric)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/012_float4.json
+++ b/tests/tests/postgresql/012_float4.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "float data type, 4 bytes size (real)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/013_float8.json
+++ b/tests/tests/postgresql/013_float8.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "float data type, 8 bits value (double precission)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/014_date.json
+++ b/tests/tests/postgresql/014_date.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "date data type",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/015_time.json
+++ b/tests/tests/postgresql/015_time.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "time data type (time without time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/016_datetime.json
+++ b/tests/tests/postgresql/016_datetime.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "datetime data type (timestamp without time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/017_datetime2.json
+++ b/tests/tests/postgresql/017_datetime2.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "datetime2 data type (timestamp without time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/018_datetimeoffset.json
+++ b/tests/tests/postgresql/018_datetimeoffset.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "datatimeoffset data type (time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/019_char.json
+++ b/tests/tests/postgresql/019_char.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "char data type",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/020_varchar.json
+++ b/tests/tests/postgresql/020_varchar.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "varchar data type",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/021_varcharmax.json
+++ b/tests/tests/postgresql/021_varcharmax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "varchar data type, maximum size",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/022_binary4.json
+++ b/tests/tests/postgresql/022_binary4.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "binary data type, 4 bytes size (bytea)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/023_varbinary4.json
+++ b/tests/tests/postgresql/023_varbinary4.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "varbinary data type, 4 bytes size (bytea)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/024_varbinarymax.json
+++ b/tests/tests/postgresql/024_varbinarymax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "varbinary data type, maximum size (bytea)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/025_null_datetime.json
+++ b/tests/tests/postgresql/025_null_datetime.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "datatime data type, null value (timestamp without time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/026_null_datetime2.json
+++ b/tests/tests/postgresql/026_null_datetime2.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "datetime2 data type, null value (timestamp without time zone)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/027_column_match_enabled.json
+++ b/tests/tests/postgresql/027_column_match_enabled.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "automated column matching enabled",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/028_column_match_disabled.json
+++ b/tests/tests/postgresql/028_column_match_disabled.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "automated column matching disabled",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/029_column_name.json
+++ b/tests/tests/postgresql/029_column_name.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "column name manual matching",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/030_query_option_column_match_enabled.json
+++ b/tests/tests/postgresql/030_query_option_column_match_enabled.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "automated column matching enabled (query option)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/031_query_option_column_match_disabled.json
+++ b/tests/tests/postgresql/031_query_option_column_match_disabled.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "automated column matching disabled (query option)",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}


### PR DESCRIPTION
For each SQL test, read a JSON file, allowing server version check (minimum and maximum if needed), as well as a description.

This will be useful to address PR #91 

Tested at [https://jenkins.juliogonzalez.es/job/tds_fdw-build-free/27/](https://jenkins.juliogonzalez.es/job/tds_fdw-build-free/27/)