### PR TITLE
Add a link to Installing on OSX.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ See [installing tds_fdw on CentOS](InstallCentOS.md).
 
 See [installing tds_fdw on Ubuntu](InstallUbuntu.md).
 
+## Installing on OSX
+
+See [installing tds_fdw on OSX](InstallOSX.md).
+
 ## Usage
 
 ### Foreign server


### PR DESCRIPTION
Curiously there's no link in the readme to Installing on OSX.  If merged, this pull request rectifies this.