### PR TITLE
Repointer the docs to tds-fdw/tds_fdw.

### DIFF
--- a/InstallCentOS.md
+++ b/InstallCentOS.md
@@ -43,7 +43,7 @@ If you'd like to use one of the release packages, you can download and install t
 
 ```bash
 export TDS_FDW_VERSION="1.0.7"
-wget https://github.com/GeoffMontee/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz -O tds_fdw-${TDS_FDW_VERSION}.tar.gz
+wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz -O tds_fdw-${TDS_FDW_VERSION}.tar.gz
 tar -xvzf tds_fdw-${TDS_FDW_VERSION}.tar.gz
 cd tds_fdw-${TDS_FDW_VERSION}
 PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1
@@ -55,7 +55,7 @@ sudo PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
-git clone https://github.com/GeoffMontee/tds_fdw.git
+git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1
 sudo PATH=/usr/pgsql-9.5/bin:$PATH make USE_PGXS=1 install

--- a/InstallOSX.md
+++ b/InstallOSX.md
@@ -34,7 +34,7 @@ Or use Postgres.app: <http://postgresapp.com/>
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-wget https://github.com/GeoffMontee/tds_fdw/archive/v1.0.7.tar.gz
+wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
 tar -xvzf tds_fdw-1.0.7.tar.gz
 cd tds_fdw-1.0.7
 make USE_PGXS=1
@@ -46,7 +46,7 @@ sudo make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
-git clone https://github.com/GeoffMontee/tds_fdw.git
+git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 make USE_PGXS=1
 sudo make USE_PGXS=1 install

--- a/InstallUbuntu.md
+++ b/InstallUbuntu.md
@@ -36,7 +36,7 @@ sudo apt-get install postgresql-9.5 postgresql-client-9.5 postgresql-server-dev-
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-wget https://github.com/GeoffMontee/tds_fdw/archive/v1.0.7.tar.gz
+wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
 tar -xvzf tds_fdw-1.0.7.tar.gz
 cd tds_fdw-1.0.7
 make USE_PGXS=1
@@ -48,7 +48,7 @@ sudo make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
-git clone https://github.com/GeoffMontee/tds_fdw.git
+git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 make USE_PGXS=1
 sudo make USE_PGXS=1 install

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ To set the client character set, you can set *client charset* in *freetds.conf*.
 
 ## Support
 
-If you find any bugs, or you would like to request enhancements, please submit your comments on the [project's GitHub Issues page](https://github.com/GeoffMontee/tds_fdw/issues).
+If you find any bugs, or you would like to request enhancements, please submit your comments on the [project's GitHub Issues page](https://github.com/tds-fdw/tds_fdw/issues).
 
 Additionally, I do subscribe to several [PostgreSQL mailing lists](http://www.postgresql.org/list/) including *pgsql-general* and *pgsql-hackers*. If tds_fdw is mentioned in an email sent to one of those lists, I typically see it.
 


### PR DESCRIPTION
The docs still refer to `https://github.com/GeoffMontee/tds_fdw`.  It appears this repo has since been moved. 

If merged, the docs now say `https://github.com/tds-fdw/tds_fdw` thus eliminating one potential source of confusion.