### PR TITLE
Remove unnecessary symbol visibility to eliminate conflict with postgres_fdw

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ PG_CONFIG    = pg_config
 
 # modify these variables to point to FreeTDS, if needed
 SHLIB_LINK := -lsybdb
-PG_CPPFLAGS := -I./include/
+PG_CPPFLAGS := -I./include/ -fvisibility=hidden
 # PG_LIBS :=
 
 all: sql/$(EXTENSION)--$(EXTVERSION).sql README.${EXTENSION}.md

--- a/include/visibility.h
+++ b/include/visibility.h
@@ -1,0 +1,9 @@
+#ifndef VISIBILITY_H
+#define VISIBILITY_H
+
+
+#if __GNUC__ >= 4
+#define PGDLLEXPORT __attribute__((visibility("default")))
+#endif
+
+#endif

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -23,6 +23,10 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+/* Override PGDLLEXPORT for visibility */
+
+#include "visibility.h"
+
 /* postgres headers */
 
 #include "postgres.h"
@@ -111,7 +115,7 @@ enum FdwScanPrivateIndex
 PG_FUNCTION_INFO_V1(tds_fdw_handler);
 PG_FUNCTION_INFO_V1(tds_fdw_validator);
 
-Datum tds_fdw_handler(PG_FUNCTION_ARGS)
+PGDLLEXPORT Datum tds_fdw_handler(PG_FUNCTION_ARGS)
 {
 	FdwRoutine *fdwroutine = makeNode(FdwRoutine);
 	
@@ -149,7 +153,7 @@ Datum tds_fdw_handler(PG_FUNCTION_ARGS)
 	PG_RETURN_POINTER(fdwroutine);
 }
 
-Datum tds_fdw_validator(PG_FUNCTION_ARGS)
+PGDLLEXPORT Datum tds_fdw_validator(PG_FUNCTION_ARGS)
 {
 	List *options_list = untransformRelOptions(PG_GETARG_DATUM(0));
 	Oid catalog = PG_GETARG_OID(1);


### PR DESCRIPTION
Note: this implementation is probably not portable. Suggestions on how to make it so are welcome.

Symbol deparseSelectSql() is used in both postgres_fdw and tds_fdw. This
symbol is exported as a global symbol in both cases as is the default
behavior for non-static functions. When tds_fdw.so is loaded before
postgres_fdw.so linker will link the implementation from tds_fdw into
postgres_fdw, causing segfaults when postgres_fdw is used.

Because there is no reason to actually export these functions this patch
adjusts build flags to default functions to non-exported and overrides
PostgreSQL PGDLLEXPORT definition to mark functions as exported. As
PG_FUNCTION_INFO_V1 does not add export flag to the actual function
declaration we need to manually annotate the exported functions.

An alternative solution would be to just rename the conflicting functions.
For platforms without -fvisibility=hidden support that might be a good
idea anyway.