### PR TITLE
Fix problem accessing INFORMATION_SCHEMA views on case sensitive databases

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -2905,7 +2905,7 @@ tdsImportSqlServerSchema(ImportForeignSchemaStmt *stmt, DBPROCESS  *dbproc,
 	initStringInfo(&buf);
 
 	/* Check that the schema really exists */
-	appendStringInfoString(&buf, "SELECT schema_name FROM information_schema.schemata WHERE schema_name = ");
+	appendStringInfoString(&buf, "SELECT schema_name FROM INFORMATION_SCHEMA.SCHEMATA WHERE schema_name = ");
 	deparseStringLiteral(&buf, stmt->remote_schema);
 
 	if (!tdsExecuteQuery(buf.data, dbproc))
@@ -2940,8 +2940,8 @@ tdsImportSqlServerSchema(ImportForeignSchemaStmt *stmt, DBPROCESS  *dbproc,
 						   "  c.numeric_precision_radix, "
 						   "  c.numeric_scale, "
 						   "  c.datetime_precision "
-						   "FROM information_schema.tables t "
-						   "  LEFT JOIN information_schema.columns c ON "
+						   "FROM INFORMATION_SCHEMA.TABLES t "
+						   "  LEFT JOIN INFORMATION_SCHEMA.COLUMNS c ON "
 						   "    t.table_schema = c.table_schema "
 						   "      AND t.table_name = c.table_name "
 						   "WHERE t.table_type = 'BASE TABLE' "

--- a/tests/tests/mssql/000_create_schema.sql
+++ b/tests/tests/mssql/000_create_schema.sql
@@ -1,6 +1,6 @@
 IF NOT EXISTS (
 SELECT  schema_name
-FROM    information_schema.schemata
+FROM    INFORMATION_SCHEMA.SCHEMATA
 WHERE   schema_name = '@SCHEMANAME')
 BEGIN
 EXEC sp_executesql N'CREATE SCHEMA @SCHEMANAME'


### PR DESCRIPTION
Even for non case sensitive databases, the schema and its views are always uppercase.

See #146, will fix it pending new version (alpha2) generation.