### PR TITLE
Fix problem accessing INFORMATION_SCHEMA views on case sensitive databases

### DIFF
--- a/tests/tests/mssql/000_create_schema.sql
+++ b/tests/tests/mssql/000_create_schema.sql
@@ -1,6 +1,6 @@
 IF NOT EXISTS (
 SELECT  schema_name
-FROM    information_schema.schemata
+FROM    INFORMATION_SCHEMA.SCHEMATA
 WHERE   schema_name = '@SCHEMANAME')
 BEGIN
 EXEC sp_executesql N'CREATE SCHEMA @SCHEMANAME'


### PR DESCRIPTION
Even for non case sensitive databases, the schema and its views are always uppercase.

See #146. Unlike 2.0.0, 1.0.x does not use INFORMATION_SCHEMA.

Therefore this PR will only fix the tests so no new 1.0.x version is required.