### PR TITLE
Fix the Problem with like. Solution from User ale2317 (see Issue #118).

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1741,11 +1741,14 @@ deparseOpExpr(OpExpr *node, deparse_expr_cxt *context)
 
 static void deparseTdsOperatorNameFromPgOp(StringInfo buf, char* opname)
 {
-	if (strncmp(opname, "!~~", NAMEDATALEN) == 0)
+	if (strncmp(opname, "!~~", NAMEDATALEN) == 0 || strncmp(opname, "!~~*", NAMEDATALEN) == 0)
 	{
 		appendStringInfoString(buf, "NOT LIKE");
 	}
-	
+	else if (strncmp(opname, "~~", NAMEDATALEN) == 0 || strncmp(opname, "~~*", NAMEDATALEN) == 0)
+    {
+        appendStringInfoString(buf, "LIKE");
+    }
 	else
 	{
 		appendStringInfoString(buf, opname);


### PR DESCRIPTION
From https://www.postgresql.org/docs/8.2/static/functions-matching.html:
The operator ~~ is equivalent to LIKE, and \~~* corresponds to ILIKE.
There are also !~~ and !~~* operators that represent NOT LIKE and NOT ILIKE, respectively. All of these operators are PostgreSQL-specific.