### PR TITLE
Import SqlServer datatype uniqueidentifier as postgres uuid.

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -3209,6 +3209,8 @@ tdsImportSqlServerSchema(ImportForeignSchemaStmt *stmt, DBPROCESS  *dbproc,
 					/* Other types */
 					else if (strcmp(data_type, "xml") == 0)
 						appendStringInfoString(&buf, " xml");
+					else if (strcmp(data_type, "uniqueidentifier") == 0)
+						appendStringInfoString(&buf, " uuid");
 					else
 					{
 						ereport(DEBUG3,


### PR DESCRIPTION
All uniqueidentifiers from SqlServer are imported as text (default path). Change this to uuid.