### PR TITLE
Adapt to core API changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.deps
+README.tds_fdw.md
+sql/*--*.sql
+*.o
+*.bc
+*.so

--- a/include/tds_fdw.h
+++ b/include/tds_fdw.h
@@ -158,6 +158,21 @@ FdwPlan* tdsPlanForeignScan(Oid foreigntableid, PlannerInfo *root, RelOptInfo *b
 List *tdsImportForeignSchema(ImportForeignSchemaStmt *stmt, Oid serverOid);
 #endif  /* IMPORT_API */
 
+/* compatibility with PostgreSQL 9.6+ */
+#ifndef ALLOCSET_DEFAULT_SIZES
+#define ALLOCSET_DEFAULT_SIZES \
+ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE
+#endif
+
+/* compatibility with PostgreSQL v11+ */
+#if PG_VERSION_NUM < 110000
+/* new in v11 */
+#define TupleDescAttr(tupdesc, i) ((tupdesc)->attrs[(i)])
+#else
+/* removed in v11 */
+#define get_relid_attribute_name(relid, varattno) get_attname((relid), (varattno), false)
+#endif
+
 /* Helper functions */
 
 bool is_builtin(Oid objectId);


### PR DESCRIPTION
- PostgreSQL commit 8237f27b504ff1d1e2da7ae4c81a7f72ea0e0e3e
  This v11 commit removed "get_relid_attribute_name", the
  replacement is "get_attname" with a third argument "false".

- PostgreSQL commit 9fa6f00b1308dd10da4eca2f31ccbfc7b35bb461
  This v11 commit removed the individual size parameters for
  AllocSetContextCreate (which is now a macro) and foced usage
  of the ALLOCSET_DEFAULT_SIZES macro (which in turn did not exist
  before 9.6).

- PostgreSQL commit c6293249dc178f52dd508c3e6ff353af41c90b58
  This v11 commit changed the internal representation of a tuple
  descriptor. You now have to use the "TupleDescAttr" macro to
  access the individual attributes.

In passing, add a ".gitignore" file.