### PR TITLE
Allow a comma separated list for "servername"

### DIFF
--- a/ForeignServerCreation.md
+++ b/ForeignServerCreation.md
@@ -19,6 +19,10 @@ Default: 127.0.0.1
 The servername, address or hostname of the foreign server server.  
   
 This can be a DSN, as specified in *freetds.conf*. See [FreeTDS name lookup](http://www.freetds.org/userguide/name.lookup.htm).
+
+You can set this option to a comma separated list of server names, then each
+server is tried until the first connection succeeds.  
+This is useful for automatic fail-over to a secondary server.
 				
 * *port*  
   


### PR DESCRIPTION
This is useful for automatic fail-over to a secondary server.

For this we have to introduce a new error handler that captures
connection errors, but does not throw an error.
The last captured error is thrown if all servers fail.