### PR TITLE
Clear the error message in the right spot

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -527,6 +527,7 @@ int tdsSetupConnection(TdsFdwOptionSet* option_set, LOGINREC *login, DBPROCESS *
 
 	/* try all server names until we find a good one */
 	servers = option_set->servername;
+	last_error_message = NULL;
 	while (servers != NULL)
 	{
 		/* find the length of the next server name */
@@ -590,7 +591,6 @@ int tdsSetupConnection(TdsFdwOptionSet* option_set, LOGINREC *login, DBPROCESS *
 
 	/* set the normal error handler again */
 	dberrhandle(tds_err_handler);
-	last_error_message = NULL;
 
 	if (option_set->database && option_set->dbuse)
 	{


### PR DESCRIPTION
I don't think that it really can happen that "dbproc" is NULL
without an error message (and hence the ereport around
line 586 is probably dead code), but let's be safe.