### PR TITLE
Improve OSX install

### DIFF
--- a/InstallOSX.md
+++ b/InstallOSX.md
@@ -6,7 +6,7 @@
 
 ## Installing on OSX
 
-This document will show how to install tds_fdw on OSX.
+This document will show how to install tds_fdw on OSX using the [Homebrew](https://brew.sh/) package manager for the required packages.
 
 ### Install FreeTDS
 
@@ -16,6 +16,8 @@ such as [FreeTDS](http://www.freetds.org).
 ```bash
 brew install freetds
 ```
+
+Note: If you install FreeTDS from another source, e.g. [MacPorts](https://www.macports.org), you might have to adjust the value for `TDS_INCLUDE` in the make calls below.
 
 ### Install PostgreSQL
 
@@ -37,7 +39,7 @@ If you'd like to use one of the release packages, you can download and install t
 wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
 tar -xvzf tds_fdw-1.0.7.tar.gz
 cd tds_fdw-1.0.7
-make USE_PGXS=1
+make USE_PGXS=1 TDS_INCLUDE=-/usr/local/include/
 sudo make USE_PGXS=1 install
 ```
 
@@ -48,7 +50,7 @@ If you would rather use the current development version, you can clone and build
 ```bash
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
-make USE_PGXS=1
+make USE_PGXS=1 TDS_INCLUDE=-/usr/local/include/
 sudo make USE_PGXS=1 install
 ```
 
@@ -57,7 +59,7 @@ sudo make USE_PGXS=1 install
 If this is a fresh installation, then start the server:
 
 ```bash
-sudo /etc/init.d/postgresql start
+brew services start postgresql
 ```
 
 #### Install extension

--- a/InstallOSX.md
+++ b/InstallOSX.md
@@ -17,7 +17,7 @@ such as [FreeTDS](http://www.freetds.org).
 brew install freetds
 ```
 
-Note: If you install FreeTDS from another source, e.g. [MacPorts](https://www.macports.org), you might have to adjust the value for `TDS_INCLUDE` in the make calls below.
+Note: If you install FreeTDS from another source, e.g. [MacPorts](https://www.macports.org), you might have to adjust the value for `TDS_INCLUDE` in the make calls below  (e.g. `-I/opt/local/include/freetds` for MacPorts).
 
 ### Install PostgreSQL
 
@@ -39,7 +39,7 @@ If you'd like to use one of the release packages, you can download and install t
 wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
 tar -xvzf tds_fdw-1.0.7.tar.gz
 cd tds_fdw-1.0.7
-make USE_PGXS=1 TDS_INCLUDE=-/usr/local/include/
+make USE_PGXS=1 TDS_INCLUDE=-I/usr/local/include/
 sudo make USE_PGXS=1 install
 ```
 
@@ -50,7 +50,7 @@ If you would rather use the current development version, you can clone and build
 ```bash
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
-make USE_PGXS=1 TDS_INCLUDE=-/usr/local/include/
+make USE_PGXS=1 TDS_INCLUDE=-I/usr/local/include/
 sudo make USE_PGXS=1 install
 ```
 
@@ -61,6 +61,8 @@ If this is a fresh installation, then start the server:
 ```bash
 brew services start postgresql
 ```
+
+Or the equivalent command if you are not using Homebrew.
 
 #### Install extension
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,8 @@ PG_CONFIG    = pg_config
 
 # modify these variables to point to FreeTDS, if needed
 SHLIB_LINK := -lsybdb
-PG_CPPFLAGS := -I./include/ -fvisibility=hidden
+TDS_INCLUDE :=
+PG_CPPFLAGS := -I./include/ -fvisibility=hidden ${TDS_INCLUDE}
 # PG_LIBS :=
 
 all: sql/$(EXTENSION)--$(EXTVERSION).sql README.${EXTENSION}.md

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # This is a PostgreSQL foreign data wrapper for use to connect to databases that use TDS,
 # such as Sybase databases and Microsoft SQL server.
 #
-# This foreign data wrapper requires requires a library that uses the DB-Library interface,
+# This foreign data wrapper requires a library that uses the DB-Library interface,
 # such as FreeTDS (http://www.freetds.org/). This has been tested with FreeTDS, but not
 # the proprietary implementations of DB-Library.
 #----------------------------------------------------------------------------
@@ -43,7 +43,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql README.${EXTENSION}.md
 
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
-	
+
 README.${EXTENSION}.md: README.md
 	cp $< $@
 


### PR DESCRIPTION
@juliogonzalez Hi, this is my try. It goes a bit further than your pull request #198 e.g. I noticed that the instruction of how to start the Postgres Server don't apply to macOS. So I fixed that, too.

At first, I considered OS detection in the Makefile, but that actually didn't solve our underlying problem in case other package managers (MacPorts,...) are used. So I left that for when it's needed. 

Fixes #197 