### PR TITLE
Change mentions from openSUSE Leap 42.3 to 15.1 and use correct capitalization

### DIFF
--- a/InstallopenSUSE.md
+++ b/InstallopenSUSE.md
@@ -4,9 +4,9 @@
 * **Name:** tds_fdw
 * **File:** tds_fdw/InstallopenSUSE.md
 
-## Installing on OpenSUSE
+## Installing on openSUSE
 
-This document will show how to install tds_fdw on openSUSE Leap 42.3. Other OpenSUSE and SUSE distributions should be similar. 
+This document will show how to install tds_fdw on openSUSE Leap 15.1. Other openSUSE and SUSE distributions should be similar. 
 
 ### Install FreeTDS
 
@@ -19,10 +19,10 @@ sudo zypper install freetds freetds-dev
 
 ### Install PostgreSQL
 
-If you need to install PostgreSQL, for example, 9.5:
+If you need to install PostgreSQL, for example, 10.X:
 
 ```bash
-sudo zypper install postgresql95 postgresql95-server postgresql95-devel
+sudo zypper install postgresql10 postgresql10-server postgresql10-devel
 ```
 
 ### Install tds_fdw

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ See [installing tds_fdw on CentOS](InstallCentOS.md).
 
 See [installing tds_fdw on Ubuntu](InstallUbuntu.md).
 
-## Installing on OpenSUSE
+## Installing on openSUSE
 
-See [installing tds_fdw on OpenSUSE](InstallOpenSUSE.md).
+See [installing tds_fdw on openSUSE](InstallopenSUSE.md).
 
 ## Installing on OSX
 


### PR DESCRIPTION
openSUSE Leap 42.3 is now EoL, so instructions are changed to 15.1 (which has PostgreSQL 9.6 and 10, so we use the occasion to use 10.X for the example)

I am also fixing the capitalization. The correct name is `openSUSE` and not `OpenSUSE`.