### PR TITLE
Add PostgreSQL 12 support w/ new types+ExecTuple func

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1251,10 +1251,10 @@ deparseRelation(StringInfo buf, Relation rel)
 	 * Note: we could skip printing the schema name if it's pg_catalog, but
 	 * that doesn't seem worth the trouble.
 	 */
-	/*if (nspname == NULL)
+	if (nspname == NULL)
 		nspname = get_namespace_name(RelationGetNamespace(rel));
 	if (relname == NULL)
-		relname = RelationGetRelationName(rel);*/
+		relname = RelationGetRelationName(rel);
 
 	if (nspname == NULL)
 		appendStringInfo(buf, "%s",

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1251,11 +1251,13 @@ deparseRelation(StringInfo buf, Relation rel)
 	 * Note: we could skip printing the schema name if it's pg_catalog, but
 	 * that doesn't seem worth the trouble.
 	 */
+	 #if PG_VERSION_NUM >= 120000
 	if (nspname == NULL)
 		nspname = get_namespace_name(RelationGetNamespace(rel));
 	if (relname == NULL)
 		relname = RelationGetRelationName(rel);
-
+	#endif
+	
 	if (nspname == NULL)
 		appendStringInfo(buf, "%s",
 					 relname);

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1252,12 +1252,15 @@ deparseRelation(StringInfo buf, Relation rel)
 	 * that doesn't seem worth the trouble.
 	 */
 	 #if PG_VERSION_NUM >= 120000
+	 /* nspname is PostgreSQL schema, and should not be appended */
+	 /*
 	if (nspname == NULL)
 		nspname = get_namespace_name(RelationGetNamespace(rel));
+	*/
 	if (relname == NULL)
 		relname = RelationGetRelationName(rel);
 	#endif
-	
+
 	if (nspname == NULL)
 		appendStringInfo(buf, "%s",
 					 relname);

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -45,7 +45,11 @@
 #include "optimizer/cost.h"
 #include "optimizer/paths.h"
 #include "optimizer/prep.h"
+#if (PG_VERSION_NUM < 120000)
 #include "optimizer/var.h"
+#else
+#include "optimizer/optimizer.h"
+#endif
 #include "storage/fd.h"
 #include "utils/array.h"
 #include "utils/builtins.h"
@@ -1837,8 +1841,11 @@ TupleTableSlot* tdsIterateForeignScan(ForeignScanState *node)
 				}
 
 				tuple = heap_form_tuple(node->ss.ss_currentRelation->rd_att, festate->datums, festate->isnull);
+#if PG_VERSION_NUM < 120000
 				ExecStoreTuple(tuple, slot, InvalidBuffer, false);
-				
+#else
+				ExecStoreHeapTuple(tuple, slot, false);
+#endif				
 				break;
 				
 			case BUF_FULL:


### PR DESCRIPTION
This patch allows use of tds_fdw with PG12.
This implies #211 observations :

  * `ArrayRef` was changed to  `SubscriptingRef`
  * `ExecStoreTuple` was split into two functions due to Pluggable storage engine
  * Includes layout have changed

This patch was tested against PG 12 RC1 on a centos/7 with pgdg source. It may also still work on older version of PG as all changes were protected by preoprocessor instructions.