### PR TITLE
Add `--debugging`, `--unattended-debugging` and  `--tds_version` parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,3 +92,7 @@ If you find any bugs, or you would like to request enhancements, please submit y
 
 Additionally, I do subscribe to several [PostgreSQL mailing lists](http://www.postgresql.org/list/) including *pgsql-general* and *pgsql-hackers*. If tds_fdw is mentioned in an email sent to one of those lists, I typically see it.
 
+## Debugging
+
+See [Debugging](tests/README.md)
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,23 @@
+# Testing scripts
+
+Testing should follow that workflow :
+
+  * First build a MSSQL Server
+    1. Create the server (local, container, VM or azure)
+    2. Create a testing database with a proper user and access privileges
+    3. Run `mssql-tests.py` against that server.
+  * Next, build a PostgreSQL Server
+    1. Create the server (on your machine, with docker o rVM)
+    2. Compile and install tds_fdw extension
+    3. Create a testing database and schema with proper user and access privilege
+    4. On that database you'll have first to install tds_fdw: `CREATE EXTENSION tds_fdw;`
+    5. You can run `postgresql_test.py`
+
+# Debugging
+
+It may be interesting to build a full setup for debugging purpose and use tests to check if anythong regresses.
+For this, you can use `--debugging` parameter at `postgresql-tests.py` launch time.
+
+The test program will stop just after connection creation and give you the backend PID used for testing. This will allow you to connect gdb in another shell session (`gdb --pid=<PID>`). Once connected with gdb, just put breakpoints where you need and run `cont`. Then you can press any key in the test shell script to start testing.
+
+Also, in case of test failure, `--debugging` will allow to define quite precisely where the script crashed using psycopg2 `Diagnostics` class information and will give the corresponding SQL injected in PostgreSQL.

--- a/tests/lib/messages.py
+++ b/tests/lib/messages.py
@@ -9,7 +9,7 @@ class bcolors:
 
 def print_error(msg):
     """Print an error message in red"""
-    print (bcolors.BOLDRED + "[ERROR] %s" % msg + bcolors.RESET)
+    print(bcolors.BOLDRED + "[ERROR] %s" % msg + bcolors.RESET)
 
 
 def print_warning(msg):

--- a/tests/lib/messages.py
+++ b/tests/lib/messages.py
@@ -9,22 +9,22 @@ class bcolors:
 
 def print_error(msg):
     """Print an error message in red"""
-    print bcolors.BOLDRED + "[ERROR] %s" % msg + bcolors.RESET
+    print (bcolors.BOLDRED + "[ERROR] %s" % msg + bcolors.RESET)
 
 
 def print_warning(msg):
     """Print a warning message in yellow"""
-    print bcolors.BOLDYELLOW + "[WARNING] %s" % msg + bcolors.RESET
+    print(bcolors.BOLDYELLOW + "[WARNING] %s" % msg + bcolors.RESET)
 
 
 def print_ok(msg):
     """Print an ok message in green"""
-    print bcolors.BOLDGREEN + "[OK] %s" % msg + bcolors.RESET
+    print(bcolors.BOLDGREEN + "[OK] %s" % msg + bcolors.RESET)
 
 
 def print_info(msg):
     """Print an info message in cyan"""
-    print bcolors.BOLDCYAN + "[INFO] %s" % msg + bcolors.RESET
+    print(bcolors.BOLDCYAN + "[INFO] %s" % msg + bcolors.RESET)
 
 
 def print_report(total, ok, error):
@@ -48,6 +48,6 @@ def print_usage_error(script, error):
     script -- A string with the script filename (without path)
     error  -- A string with an error
     """
-    print 'Usage: %s <arguments>' % script
-    print ''
-    print '%s: error: %s' % (script, error)
+    print('Usage: %s <arguments>' % script)
+    print('')
+    print('%s: error: %s' % (script, error))

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -91,10 +91,10 @@ def run_tests(path, conn, replaces, dbtype, debugging):
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)
-            if debugging:
-                print_error("Sent query : %s"%sentence)
-                for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
-                    print_error("%s : %s"%(att, getattr(e.diag,att)))
+                    if debugging:
+                        print_error("Sent query : %s"%sentence)
+                        for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
+                            print_error("%s : %s"%(att, getattr(e.diag,att)))
                 except:
                     print_error(e)
                 conn.rollback()

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -56,7 +56,7 @@ def check_ver(conn, min_ver, max_ver, dbtype):
         return(False)
 
 
-def run_tests(path, conn, replaces, dbtype, args):
+def run_tests(path, conn, replaces, dbtype, debugging):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:
@@ -91,10 +91,10 @@ def run_tests(path, conn, replaces, dbtype, args):
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)
-		    if args.debugging:
-			print_error("Sent query : %s"%sentence)
-			for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
-                            print_error("%s : %s"%(att, getattr(e.diag,att)))
+            if debugging:
+                print_error("Sent query : %s"%sentence)
+                for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
+                    print_error("%s : %s"%(att, getattr(e.diag,att)))
                 except:
                     print_error(e)
                 conn.rollback()

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -1,7 +1,8 @@
 from glob import glob
 from json import load
 from lib.messages import print_error, print_info
-from os.path import basename
+from os import listdir
+from os.path import basename, isfile, realpath
 from re import match
 from psycopg2.extensions import Diagnostics
 
@@ -55,6 +56,54 @@ def check_ver(conn, min_ver, max_ver, dbtype):
     else:
         return(False)
 
+def get_logs_path(conn, dbtype):
+    """ Get PostgreSQL logs
+
+    Keyword arguments:
+    conn  -- A db connection (according to Python DB API v2.0)
+    dbtye -- A string with the database type (postgresql|mssql). mssql will return an empty a array.
+    """
+    logs = []
+    if dbtype == 'mssql':
+        return(logs)
+    cursor = conn.cursor()
+    try:
+        cursor.execute("SELECT setting FROM pg_catalog.pg_settings WHERE name = 'data_directory';")
+        data_dir = cursor.fetchone()[0]
+    except TypeError:
+        print_error("The user does not have SUPERUSER access to PostgreSQL.")
+        print_error("Cannot access pg_catalog.pg_settings required values, so logs cannot be found")
+        return(logs)
+    cursor.execute("SELECT setting FROM pg_catalog.pg_settings WHERE name = 'log_directory';")
+    log_dir = cursor.fetchone()[0]
+    if log_dir[0] != '/':
+        log_dir = "%s/%s" % (data_dir, log_dir)
+    cursor.execute("SELECT setting FROM pg_catalog.pg_settings WHERE name = 'logging_collector';")
+    # No logging collector, add stdout from postmaster (assume stderr is redirected to stdout)
+    if cursor.fetchone()[0] == 'off':
+        with open("%s/postmaster.pid" % data_dir, "r") as f:
+            postmaster_pid = f.readline().rstrip('\n')
+        postmaster_log = "/proc/%s/fd/1" % postmaster_pid
+        if isfile(postmaster_log):
+            logs.append(realpath(postmaster_log))
+    # Logging collector enabled
+    else:
+        # Add stdout from logger (assume stderr is redirected to stdout)
+        pids = [pid for pid in listdir('/proc') if pid.isdigit()]
+        for pid in pids:
+            try:
+                cmdline = open('/proc/' + pid + '/cmdline', 'rb').read()
+                if 'postgres: logger' in cmdline:
+                    logger_log = "/proc/%s/fd/2" % pid
+                    if isfile(logger_log):
+                        logs.append(realpath(logger_log))
+            except IOError: # proc has already terminated
+                continue
+        # Add all files from log_dir
+        for f in listdir(log_dir):
+            logs.append(realpath(log_dir + '/' + f))
+    return(logs)
+
 
 def run_tests(path, conn, replaces, dbtype, debugging=False, unattended_debugging=False):
     """Run SQL tests over a connection, returns a dict with results.
@@ -81,7 +130,8 @@ def run_tests(path, conn, replaces, dbtype, debugging=False, unattended_debuggin
                 sentence = sentence.replace(key, elem)
             print_info("%s: Testing %s" % (test_number, test_desc))
             if debugging or unattended_debugging:
-                print_error("Query : %s" % sentence)
+                print_info("Query:")
+                print(sentence)
             try:
                 cursor = conn.cursor()
                 cursor.execute(sentence)
@@ -90,7 +140,8 @@ def run_tests(path, conn, replaces, dbtype, debugging=False, unattended_debuggin
                 tests['ok'] += 1
             except Exception as e:
                 print_error("Error running %s (%s)" % (test_desc, fname))
-                print_error("Query : %s" % sentence)
+                print_error("Query:")
+                print(sentence)
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -56,7 +56,7 @@ def check_ver(conn, min_ver, max_ver, dbtype):
         return(False)
 
 
-def run_tests(path, conn, replaces, dbtype, debugging):
+def run_tests(path, conn, replaces, dbtype, debugging = False):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -55,7 +55,7 @@ def check_ver(conn, min_ver, max_ver, dbtype):
         return(False)
 
 
-def run_tests(path, conn, replaces, dbtype):
+def run_tests(path, conn, replaces, dbtype, args):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:
@@ -90,6 +90,14 @@ def run_tests(path, conn, replaces, dbtype):
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)
+		    if args.debugging:
+			print_error("Sent query : %s"%sentence)
+                        for att in ['column_name','constraint_name','context','datatype_name',
+                                    'internal_position','internal_query','message_detail','message_hint',
+                                    'message_primary','schema_name','severity','severity_nonlocalized',
+                                    'source_file','source_function','source_line','sqlstate',
+                                    'statement_position','table_name']:
+                            print_error("%s : %s"%(att, getattr(e.diag,att)))
                 except:
                     print_error(e)
                 conn.rollback()

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -1,6 +1,6 @@
 from glob import glob
 from json import load
-from messages import print_error, print_info
+from lib.messages import print_error, print_info
 from os.path import basename
 from re import match
 from psycopg2.extensions import Diagnostics

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -3,6 +3,7 @@ from json import load
 from messages import print_error, print_info
 from os.path import basename
 from re import match
+from psycopg2.extensions import Diagnostics
 
 
 def version_to_array(version, dbtype):
@@ -92,11 +93,7 @@ def run_tests(path, conn, replaces, dbtype, args):
                     print_error(e.pgerror)
 		    if args.debugging:
 			print_error("Sent query : %s"%sentence)
-                        for att in ['column_name','constraint_name','context','datatype_name',
-                                    'internal_position','internal_query','message_detail','message_hint',
-                                    'message_primary','schema_name','severity','severity_nonlocalized',
-                                    'source_file','source_function','source_line','sqlstate',
-                                    'statement_position','table_name']:
+			for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
                             print_error("%s : %s"%(att, getattr(e.diag,att)))
                 except:
                     print_error(e)

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -56,7 +56,7 @@ def check_ver(conn, min_ver, max_ver, dbtype):
         return(False)
 
 
-def run_tests(path, conn, replaces, dbtype, debugging = False):
+def run_tests(path, conn, replaces, dbtype, details = False):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:
@@ -88,10 +88,12 @@ def run_tests(path, conn, replaces, dbtype, debugging = False):
                 tests['ok'] += 1
             except Exception as e:
                 print_error("Error running %s (%s)" % (test_desc, fname))
+                if details:
+                    print_error("Sent query : %s"%sentence)
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)
-                    if debugging:
+                    if details:
                         print_error("Sent query : %s"%sentence)
                         for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
                             print_error("%s : %s"%(att, getattr(e.diag,att)))

--- a/tests/lib/tests.py
+++ b/tests/lib/tests.py
@@ -56,7 +56,7 @@ def check_ver(conn, min_ver, max_ver, dbtype):
         return(False)
 
 
-def run_tests(path, conn, replaces, dbtype, details = False):
+def run_tests(path, conn, replaces, dbtype, debugging=False, unattended_debugging=False):
     """Run SQL tests over a connection, returns a dict with results.
 
     Keyword arguments:
@@ -80,6 +80,8 @@ def run_tests(path, conn, replaces, dbtype, details = False):
             for key, elem in replaces.items():
                 sentence = sentence.replace(key, elem)
             print_info("%s: Testing %s" % (test_number, test_desc))
+            if debugging or unattended_debugging:
+                print_error("Query : %s" % sentence)
             try:
                 cursor = conn.cursor()
                 cursor.execute(sentence)
@@ -88,15 +90,12 @@ def run_tests(path, conn, replaces, dbtype, details = False):
                 tests['ok'] += 1
             except Exception as e:
                 print_error("Error running %s (%s)" % (test_desc, fname))
-                if details:
-                    print_error("Sent query : %s"%sentence)
+                print_error("Query : %s" % sentence)
                 try:
                     print_error(e.pgcode)
                     print_error(e.pgerror)
-                    if details:
-                        print_error("Sent query : %s"%sentence)
-                        for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
-                            print_error("%s : %s"%(att, getattr(e.diag,att)))
+                    for att in [member for member in dir(Diagnostics) if not member.startswith("__")]:
+                        print_error("%s: %s"%(att, getattr(e.diag,att)))
                 except:
                     print_error(e)
                 conn.rollback()

--- a/tests/mssql-tests.py
+++ b/tests/mssql-tests.py
@@ -4,6 +4,9 @@ from lib.messages import print_usage_error, print_warning
 from lib.tests import run_tests
 from optparse import OptionParser
 from os import path
+
+DEFAULT_TDS_VERSION="7.1"
+
 try:
     from pymssql import connect
 except:
@@ -32,8 +35,8 @@ def parse_options():
     parser.add_option('--azure', action='store_true', default=False,
                       help='If present, will connect as Azure, otherwise as '
                            'standard MSSQL')
-    parser.add_option('--tds_version', action="store", default="7.1",
-                      help='Specifies th TDS protocol version')
+    parser.add_option('--tds_version', action="store", default=DEFAULT_TDS_VERSION,
+                      help='Specifies th TDS protocol version, default="%s"'%DEFAULT_TDS_VERSION)
     (options, args) = parser.parse_args()
     # Check for test parameters
     if (options.server is None or
@@ -58,9 +61,6 @@ def main():
         print_usage_error(path.basename(__file__), e)
         exit(2)
     try:
-        # For our tests, tds_version 7.1 is enough and is the default
-        # tds_version can be enforced using --tds_version switch
-        # to apply test on a different MSSQL version
         conn = connect(server=args.server, user=args.username,
                        password=args.password, database=args.database,
                        port=args.port, tds_version=args.tds_version)

--- a/tests/mssql-tests.py
+++ b/tests/mssql-tests.py
@@ -32,6 +32,8 @@ def parse_options():
     parser.add_option('--azure', action='store_true', default=False,
                       help='If present, will connect as Azure, otherwise as '
                            'standard MSSQL')
+    parser.add_option('--tds_version', action="store", default="7.1",
+                      help='Specifies th TDS protocol version')
     (options, args) = parser.parse_args()
     # Check for test parameters
     if (options.server is None or
@@ -56,10 +58,12 @@ def main():
         print_usage_error(path.basename(__file__), e)
         exit(2)
     try:
-        # For our tests, tds_version 7.1 is enough
+        # For our tests, tds_version 7.1 is enough and is the default
+        # tds_version can be enforced using --tds_version switch
+        # to apply test on a different MSSQL version
         conn = connect(server=args.server, user=args.username,
                        password=args.password, database=args.database,
-                       port=args.port, tds_version='7.1')
+                       port=args.port, tds_version=args.tds_version)
         replaces = {'@SCHEMANAME': args.schema}
         tests = run_tests('tests/mssql/*.sql', conn, replaces, 'mssql')
         print_report(tests['total'], tests['ok'], tests['errors'])

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -110,7 +110,7 @@ def main():
                           args.debugging, args.unattended_debugging)
         print_report(tests['total'], tests['ok'], tests['errors'])
         logs = get_logs_path(conn, 'postgresql')
-        if tests['errors'] != 0 or args.unattended_debugging:
+        if (tests['errors'] != 0 or args.unattended_debugging) and not args.debugging:
             for fpath in logs:
                 print_info("=========== Content of %s ===========" % fpath)
                 with open(fpath, "r") as f:

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -86,11 +86,11 @@ def main():
                        password=args.postgres_password,
                        database=args.postgres_database,
                        port=args.postgres_port)
-	if args.debugging:
-	    curs = conn.cursor()
-	    curs.execute("SELECT pg_backend_pid()")
-	    print("Backend PID = %d"%curs.fetchone()[0])
-	    raw_input()
+        if args.debugging:
+            curs = conn.cursor()
+            curs.execute("SELECT pg_backend_pid()")
+            print("Backend PID = %d"%curs.fetchone()[0])
+            raw_input()
         replaces = {'@PSCHEMANAME': args.postgres_schema,
                     '@PUSER': args.postgres_username,
                     '@MSERVER': args.mssql_server,

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -49,6 +49,8 @@ def parse_options():
                            'after backend PID and before launching tests, will'
                            ' also display contextual SQL query + detailled '
                            ' errors')
+    parser.add_option('--tds_version', action="store", default="7.1",
+                      help='Specifies th TDS protocol version')
 
     (options, args) = parser.parse_args()
     # Check for test parameters
@@ -96,7 +98,8 @@ def main():
                     '@MUSER': args.mssql_username,
                     '@MPASSWORD': args.mssql_password,
                     '@MDATABASE': args.mssql_database,
-                    '@MSCHEMANAME': args.mssql_schema}
+                    '@MSCHEMANAME': args.mssql_schema,
+                    '@TDSVERSION' : args.tds_version}
         tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql', args)
         print_report(tests['total'], tests['ok'], tests['errors'])
         if tests['errors'] != 0:

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -100,7 +100,7 @@ def main():
                     '@MDATABASE': args.mssql_database,
                     '@MSCHEMANAME': args.mssql_schema,
                     '@TDSVERSION' : args.tds_version}
-        tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql', args)
+        tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql', args.debugging)
         print_report(tests['total'], tests['ok'], tests['errors'])
         if tests['errors'] != 0:
             exit(5)

--- a/tests/postgresql-tests.py
+++ b/tests/postgresql-tests.py
@@ -44,6 +44,12 @@ def parse_options():
     parser.add_option('--azure', action="store_true", default=False,
                       help='If present, will connect as Azure, otherwise as '
                            'standard MSSQL')
+    parser.add_option('--debugging', action="store_true", default=False,
+                      help='If present, will display debug information and pause '
+                           'after backend PID and before launching tests, will'
+                           ' also display contextual SQL query + detailled '
+                           ' errors')
+
     (options, args) = parser.parse_args()
     # Check for test parameters
     if (options.postgres_server is None or
@@ -78,6 +84,11 @@ def main():
                        password=args.postgres_password,
                        database=args.postgres_database,
                        port=args.postgres_port)
+	if args.debugging:
+	    curs = conn.cursor()
+	    curs.execute("SELECT pg_backend_pid()")
+	    print("Backend PID = %d"%curs.fetchone()[0])
+	    raw_input()
         replaces = {'@PSCHEMANAME': args.postgres_schema,
                     '@PUSER': args.postgres_username,
                     '@MSERVER': args.mssql_server,
@@ -86,7 +97,7 @@ def main():
                     '@MPASSWORD': args.mssql_password,
                     '@MDATABASE': args.mssql_database,
                     '@MSCHEMANAME': args.mssql_schema}
-        tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql')
+        tests = run_tests('tests/postgresql/*.sql', conn, replaces, 'postgresql', args)
         print_report(tests['total'], tests['ok'], tests['errors'])
         if tests['errors'] != 0:
             exit(5)

--- a/tests/tests/postgresql/001_create_server.sql
+++ b/tests/tests/postgresql/001_create_server.sql
@@ -2,4 +2,4 @@ DROP SERVER IF EXISTS mssql_svr CASCADE;
 
 CREATE SERVER mssql_svr
        FOREIGN DATA WRAPPER tds_fdw
-       OPTIONS (servername '@MSERVER', port '@MPORT', database '@MDATABASE', tds_version '7.1', msg_handler 'blackhole');
+       OPTIONS (servername '@MSERVER', port '@MPORT', database '@MDATABASE', tds_version '@TDSVERSION', msg_handler 'blackhole');


### PR DESCRIPTION
`--debugging` display PostgreSQL backend PID and waits for key to be pressed allowing `gdb --pid=<PID>` for debugging purpose (in another session). It also prints the SQL sentences being executed and displays display more precise informations on test crash location using `psycopg2.extensions.Diagnostics` class

`--unattended-debugging` does almost the same as `debugging`, but it doesn't pause, and writes the PostgreSQL logs to console.

`--tds_version` allows to specify tds version at test time (both in mssql testing and pgsql testing)

This PR will also now print PostgreSQL logs if there are errors.