### PR TITLE
Update doc to recent OS and PostgreSQL versions and several improvements

### DIFF
--- a/InstallCentOS.md
+++ b/InstallCentOS.md
@@ -4,38 +4,41 @@
 * **Name:** tds_fdw
 * **File:** tds_fdw/InstallCentOS.md
 
+
 ## Installing on CentOS/RHEL
 
-This document will show how to install tds_fdw on CentOS 6 and 7. RHEL distributions should be similar. 
+This document will show how to install tds_fdw on CentOS 7.6.1810. RHEL distributions should be similar.
 
-### Install PostgreSQL
-
-If you need to install PostgreSQL, do so by following the [yum installation directions](https://wiki.postgresql.org/wiki/YUM_Installation). For example, to install PostgreSQL 9.5 on CentOS 7:
-
-```bash
-wget https://download.postgresql.org/pub/repos/yum/9.5/redhat/rhel-7-x86_64/pgdg-centos95-9.5-2.noarch.rpm
-sudo rpm -ivh pgdg-centos95-9.5-2.noarch.rpm
-sudo yum install postgresql95 postgresql95-server postgresql95-libs postgresql95-devel
-```
-
-### Install EPEL
-
-In CentOS, you need the [EPEL repository installed](https://fedoraproject.org/wiki/EPEL) to install FreeTDS.
-
-```bash
-sudo yum install epel-release
-```
-
-### Install FreeTDS
+### Install FreeTDS and build dependencies
 
 The TDS foreign data wrapper requires a library that implements the DB-Library interface,
 such as [FreeTDS](http://www.freetds.org).
 
+**NOTE:** In CentOS, you need the [EPEL repository installed](https://fedoraproject.org/wiki/EPEL) to install FreeTDS
+
 ```bash
-sudo yum install freetds freetds-devel
+sudo yum install epel-release
+sudo yum install freetds-devel
 ```
 
-### Option A: Yum (released versions)
+Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
+
+```bash
+sudo yum install gcc make wget
+```
+
+### Install PostgreSQL
+
+If you need to install PostgreSQL, do so by following the [yum installation directions](https://wiki.postgresql.org/wiki/YUM_Installation). For example, to install PostgreSQL 11 on CentOS 7:
+
+```bash
+sudo rpm -i https://download.postgresql.org/pub/repos/yum/reporpms/EL-7-x86_64/pgdg-redhat-repo-latest.noarch.rpm
+sudo yum install postgresql11 postgresql11-server postgresql11-libs postgresql11-devel
+```
+
+### Install tds_fdw
+
+#### Option A: Yum (released versions)
 
 The project maintains a yum repository for CentOS6 and CentOS7 at [https://tds-fdw.github.io/yum/](https://tds-fdw.github.io/yum/)
 
@@ -47,9 +50,9 @@ Simply add the repository to your system with the following command, as root
 curl https://tds-fdw.github.io/yum/tds_fdw.repo -o /etc/yum.repos.d/tds_fdw.repo
 ```
 
-And then install the package, for example for PostgreSQL 9.5:
+And then install the package, for example for PostgreSQL 11:
 ```bash
-yum install postgresql-95-tds_fdw
+yum install postgresql-11-tds_fdw
 ```
 
 As both the metadata for the repository and the packages are signed with GPG, you will need to accept the GPG public key.
@@ -60,9 +63,9 @@ Key        : 0x9E416BBF
 Fingerprint: 9cf6 0f27 53c5 4d64 01f0 66a5 41c3 07f4 9e41 6bbf
 ```
 
-### Option B: Compile tds_fdw
+#### Option B: Compile tds_fdw
 
-#### CentOS7 and PostgreSQL >= 11
+##### CentOS7 and PostgreSQL >= 11
 
 When using the official PostgreSQL packages from postgresql.org, JIT with bitcode is enabled by default and will require llvm5 and `clang` from LLVM7 installed at `/opt/rh/llvm-toolset-7/root/usr/bin/clang` to be able to compile.
 
@@ -75,17 +78,17 @@ sudo yum install centos-release-scl
 sudo yum install llvm-toolset-7-clang llvm5.0
 ```
 
-#### Build from release package
+##### Build from release package
 
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="1.0.7"
+export TDS_FDW_VERSION="v2.0.0-alpha.3"
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz -O tds_fdw-${TDS_FDW_VERSION}.tar.gz
 tar -xvzf tds_fdw-${TDS_FDW_VERSION}.tar.gz
 cd tds_fdw-${TDS_FDW_VERSION}
-make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config
-sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config install
+make USE_PGXS=1 PG_CONFIG=/usr/pgsql-11/bin/pg_config
+sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-11/bin/pg_config install
 ```
 
 **NOTE:** If you have several PostgreSQL versions and you do not want to build for the default one, first locate where the binary for `pg_config` is, take note of the full path, then adjust `PG_CONFIG` accordingly.
@@ -95,10 +98,11 @@ sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
+yum install git
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
-make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config
-sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config install
+make USE_PGXS=1 PG_CONFIG=/usr/pgsql-11/bin/pg_config
+sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-11/bin/pg_config install
 ```
 
 **NOTE:** If you have several PostgreSQL versions and you do not want to build for the default one, first locate where the binary for `pg_config` is, take note of the full path, then adjust `PG_CONFIG` accordingly.
@@ -110,13 +114,14 @@ sudo make USE_PGXS=1 PG_CONFIG=/usr/pgsql-9.5/bin/pg_config install
 If this is a fresh installation, then initialize the data directory and start the server:
 
 ```bash
-sudo /etc/init.d/postgresql-9.5 initdb
-sudo /etc/init.d/postgresql-9.5 start
+sudo /usr/pgsql-11/bin/postgresql11-setup initdb
+sudo systemctl enable postgresql-11.service
+sudo systemctl start postgresql-11.service
 ```
 
 #### Install extension
 
 ```bash
-/usr/pgsql-9.5/bin/psql -U postgres
+/usr/pgsql-11/bin/psql -U postgres
 postgres=# CREATE EXTENSION tds_fdw;
 ```

--- a/InstallDebian.md
+++ b/InstallDebian.md
@@ -8,13 +8,20 @@
 
 This document will show how to install tds_fdw on Debian 10. Other Debian distributions should be similar.
 
-### Install FreeTDS
+### Install FreeTDS and build dependencies
 
 The TDS foreign data wrapper requires a library that implements the DB-Library interface,
 such as [FreeTDS](http://www.freetds.org).
 
 ```bash
+sudo apt-get update
 sudo apt-get install libsybdb5 freetds-dev freetds-common
+```
+
+Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
+
+```bash
+sudo apt-get install gnupg gcc make
 ```
 
 ### Install PostgreSQL
@@ -22,29 +29,27 @@ sudo apt-get install libsybdb5 freetds-dev freetds-common
 If you need to install PostgreSQL, do so by following the [apt installation directions](https://wiki.postgresql.org/wiki/Apt). For example, to install PostgreSQL 11 on Debian:
 
 ```bash
-sudo bash -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list"
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo bash -c 'source /etc/os-release; echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 0xACCC4CF8
 sudo apt-get update
 sudo apt-get upgrade
 sudo apt-get install postgresql-11 postgresql-client-11 postgresql-server-dev-11
 ```
 
-#### Important
-
-If you already have PostgreSQL installed on your system be sure that the package postgresql-server-dev-XX is installed too (where XX stands for your PostgreSQL version). 
-
+**NOTE**: If you already have PostgreSQL installed on your system be sure that the package postgresql-server-dev-XX is installed too (where XX stands for your PostgreSQL version). 
 
 ### Install tds_fdw
 
 #### Build from release package
 
-With Debian 10 it's recommended to use one of the release packages.
-You can download and install them via something like the following:
+If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-wget https://github.com/tds-fdw/tds_fdw/archive/v2.0.0-alpha.3.tar.gz
-tar -xvzf v2.0.0-alpha.3.tar.gz
-cd tds_fdw-2.0.0-alpha.3/
+export TDS_FDW_VERSION="v2.0.0-alpha.3"
+sudo apt-get install wget
+wget https://github.com/tds-fdw/tds_fdw/archive/${TDS_FDW_VERSION}.gz
+tar -xvzf ${TDS_FDW_VERSION}.tar.gz
+cd tds_fdw-${TDS_FDW_VERSION}/
 make USE_PGXS=1
 sudo make USE_PGXS=1 install
 ```
@@ -56,14 +61,12 @@ sudo make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
+sudo apt-get install git
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 make USE_PGXS=1
 sudo make USE_PGXS=1 install
 ```
-
-Please note that at the moment of writing this guide is reported a problem creating the extension in Postgres using the current evelopment version.
-Everything should be fine using the latest Alpha release (previous versions not yet tested in Debian 10).
 
 **NOTE:** If you have several PostgreSQL versions and you do not want to build for the default one, first locate where the binary for `pg_config` is, take note of the full path, and then append `PG_CONFIG=<PATH>` after `USE_PGXS=1` at the `make` commands.
 
@@ -72,7 +75,7 @@ Everything should be fine using the latest Alpha release (previous versions not 
 If this is a fresh installation, then start the server:
 
 ```bash
-sudo /etc/init.d/postgresql start
+sudo service postgresql start
 ```
 
 #### Install extension

--- a/InstallUbuntu.md
+++ b/InstallUbuntu.md
@@ -6,28 +6,37 @@
 
 ## Installing on Ubuntu
 
-This document will show how to install tds_fdw on Ubuntu 16.04. Other Ubuntu distributions should be similar.
+This document will show how to install tds_fdw on Ubuntu 18.04. Other Ubuntu distributions should be similar.
 
-### Install FreeTDS
+### Install FreeTDS and build dependencies
 
 The TDS foreign data wrapper requires a library that implements the DB-Library interface,
 such as [FreeTDS](http://www.freetds.org).
 
 ```bash
+sudo apt-get update
 sudo apt-get install libsybdb5 freetds-dev freetds-common
+```
+
+Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
+
+```bash
+sudo apt-get install gnupg gcc make
 ```
 
 ### Install PostgreSQL
 
-If you need to install PostgreSQL, do so by following the [apt installation directions](https://wiki.postgresql.org/wiki/Apt). For example, to install PostgreSQL 9.5 on Ubuntu:
+If you need to install PostgreSQL, do so by following the [apt installation directions](https://wiki.postgresql.org/wiki/Apt). For example, to install PostgreSQL 11 on Ubuntu:
 
 ```bash
-sudo bash -c "echo \"deb http://apt.postgresql.org/pub/repos/apt/ $(lsb_release -c -s)-pgdg main\" > /etc/apt/sources.list.d/pgdg.list"
-wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+sudo bash -c 'source /etc/os-release; echo "deb http://apt.postgresql.org/pub/repos/apt/ ${VERSION_CODENAME}-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+sudo apt-key adv --keyserver hkp://pool.sks-keyservers.net --recv-keys 0xACCC4CF8
 sudo apt-get update
 sudo apt-get upgrade
-sudo apt-get install postgresql-9.5 postgresql-client-9.5 postgresql-server-dev-9.5
+sudo apt-get install postgresql-11 postgresql-client-11 postgresql-server-dev-11
 ```
+
+**NOTE**: If you already have PostgreSQL installed on your system be sure that the package postgresql-server-dev-XX is installed too (where XX stands for your PostgreSQL version). 
 
 ### Install tds_fdw
 
@@ -36,9 +45,11 @@ sudo apt-get install postgresql-9.5 postgresql-client-9.5 postgresql-server-dev-
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
-tar -xvzf v1.0.7.tar.gz
-cd tds_fdw-1.0.7
+export TDS_FDW_VERSION="v2.0.0-alpha.3"
+sudo apt-get install wget
+wget https://github.com/tds-fdw/tds_fdw/archive/${TDS_FDW_VERSION}.gz
+tar -xvzf ${TDS_FDW_VERSION}.tar.gz
+cd tds_fdw-${TDS_FDW_VERSION}/
 make USE_PGXS=1
 sudo make USE_PGXS=1 install
 ```
@@ -50,6 +61,7 @@ sudo make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
+sudo apt-get install git
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 make USE_PGXS=1
@@ -63,7 +75,7 @@ sudo make USE_PGXS=1 install
 If this is a fresh installation, then start the server:
 
 ```bash
-sudo /etc/init.d/postgresql start
+sudo service postgresql start
 ```
 
 #### Install extension

--- a/InstallopenSUSE.md
+++ b/InstallopenSUSE.md
@@ -8,13 +8,19 @@
 
 This document will show how to install tds_fdw on openSUSE Leap 15.1. Other openSUSE and SUSE distributions should be similar. 
 
-### Install FreeTDS
+### Install FreeTDS and build dependencies
 
 The TDS foreign data wrapper requires a library that implements the DB-Library interface,
 such as [FreeTDS](http://www.freetds.org).
 
 ```bash
-sudo zypper install freetds freetds-dev
+sudo zypper install freetds-devel
+```
+
+Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
+
+```bash
+sudo zypper install gcc make
 ```
 
 ### Install PostgreSQL
@@ -25,6 +31,8 @@ If you need to install PostgreSQL, for example, 10.X:
 sudo zypper install postgresql10 postgresql10-server postgresql10-devel
 ```
 
+**NOTE**: If you already have PostgreSQL installed on your system be sure that the package postgresqlXX-devel is installed too (where XX stands for your PostgreSQL version). 
+
 ### Install tds_fdw
 
 #### Build from release package
@@ -32,9 +40,10 @@ sudo zypper install postgresql10 postgresql10-server postgresql10-devel
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-wget https://github.com/tds-fdw/tds_fdw/archive/v1.0.7.tar.gz
-tar -xvzf tds_fdw-1.0.7.tar.gz
-cd tds_fdw-1.0.7
+export TDS_FDW_VERSION="v2.0.0-alpha.3"
+wget https://github.com/tds-fdw/tds_fdw/archive/${TDS_FDW_VERSION}.gz
+tar -xvzf ${TDS_FDW_VERSION}.tar.gz
+cd tds_fdw-${TDS_FDW_VERSION}/
 make USE_PGXS=1
 sudo make USE_PGXS=1 install
 ```
@@ -46,6 +55,7 @@ sudo make USE_PGXS=1 install
 If you would rather use the current development version, you can clone and build the git repository via something like the following:
 
 ```bash
+zypper in git
 git clone https://github.com/tds-fdw/tds_fdw.git
 cd tds_fdw
 make USE_PGXS=1


### PR DESCRIPTION
Improvements:
- Add build dependencies
- Do not depend on `lsb_release` for CentOS/Ubuntu, as it's not available at Docker images (and maybe not at minimal installations)
- Point to the most recent released tds_fdw version (`v2.0.0-alpha.3`) where appropriate (older versions are not working anymore with current supported PostgreSQL versions).
- Remove the references to master not working at Debian, as I can't reproduce the issue (https://github.com/tds-fdw/tds_fdw/issues/230#issuecomment-555720943)
- Make all instructions similar in terms of structure (where possible, CentOS requires some extra parts, and Alpine has a Dockerfile as a bonus)

**BIG EXCEPTION:** I didn't update MacOS instructions as I don't have one to validate them.