### PR TITLE
Remove bad pfree of query string

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -1925,11 +1925,6 @@ void tdsEndForeignScan(ForeignScanState *node)
 			
 		MemoryContextStats(estate->es_query_cxt);
 	}
-
-	if (festate->query)
-	{
-		pfree(festate->query);
-	}
 	
 	ereport(DEBUG3,
 		(errmsg("tds_fdw: Closing database connection")


### PR DESCRIPTION
`tdsEndForeignScan` tries to free the query string, but is just a
pointer into the `ForeignScanState` we got passed in `tdsBeginForeignScan`.
We have no business to free that memory, which is allocated in
`PortalContext` by the traffic cop and freed when the portal is done.

This leads to intermittent crashes when the `pfree` segfaults.

Here is a stack trace from such a crash seen by a customer:

```none
Core was generated by `postgres: fhin primuss_fhin app-in.primuss.rrze'.
Program terminated with signal SIGSEGV, Segmentation fault.
#0  pfree (pointer=0x5569ec064258) at mcxt.c:1060
#1  0x00007f11188fbd83 in tdsEndForeignScan (node=<optimized out>) at src/tds_fdw.c:1931
#2  0x00005569eb162d93 in ExecEndForeignScan (node=0x5569ec06c028) at nodeForeignscan.c:249
#3  0x00005569eb151b21 in ExecEndNode (node=<optimized out>) at execProcnode.c:669
#4  0x00005569eb16916c in ExecEndHashJoin (node=0x5569ec06bd88) at nodeHashjoin.c:791
#5  0x00005569eb151ae1 in ExecEndNode (node=<optimized out>) at execProcnode.c:688
#6  0x00005569eb14bf81 in ExecEndPlan (estate=0x5569ec06b858, planstate=<optimized out>) at execMain.c:1528
#7  standard_ExecutorEnd (queryDesc=0x5569ebdc9c58) at execMain.c:482
#8  0x00005569eb10ba6e in PortalCleanup (portal=<optimized out>) at portalcmds.c:305
#9  0x00005569eb3cce5f in PortalDrop (portal=0x5569ebe5a788, isTopCommit=<optimized out>) at portalmem.c:501
#10 0x00005569eb3cd376 in PreCommit_Portals (isPrepare=isPrepare@entry=false) at portalmem.c:749
#11 0x00005569eb050cdc in CommitTransaction () at xact.c:2087
#12 0x00005569eb0520b5 in CommitTransactionCommand () at xact.c:3085
#13 0x00005569eb29eed5 in finish_xact_command () at postgres.c:2662
#14 0x00005569eb2a1941 in PostgresMain (argc=<optimized out>, argv=argv@entry=0x5569ebd27db0, dbname=<optimized out>, username=<optimized out>)
    at postgres.c:4511
#15 0x00005569eb22eb7f in BackendRun (port=0x5569ebd23b80, port=0x5569ebd23b80) at postmaster.c:4526
#16 BackendStartup (port=0x5569ebd23b80) at postmaster.c:4210
#17 ServerLoop () at postmaster.c:1739
#18 0x00005569eb22faeb in PostmasterMain (argc=3, argv=<optimized out>) at postmaster.c:1412
#19 0x00005569eafcda10 in main (argc=3, argv=0x5569ebcc9620) at main.c:210
```