### PR TITLE
EXPLAIN (VERBOSE) shows remote query

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ See [importing a foreign schema](ForeignSchemaImporting.md).
 ### Variables
 
 See [variables](Variables.md).
+
+### `EXPLAIN`
+
+`EXPLAIN (VERBOSE)` will show the query issued on the remote system.
 	
 ## Notes about character sets/encoding
 

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -1227,11 +1227,16 @@ char* tdsConvertToCString(DBPROCESS* dbproc, int srctype, const BYTE* src, DBINT
 
 void tdsExplainForeignScan(ForeignScanState *node, ExplainState *es)
 {
+	TdsFdwExecutionState *festate = (TdsFdwExecutionState *) node->fdw_state;
+
 	#ifdef DEBUG
 		ereport(NOTICE,
 			(errmsg("----> starting tdsExplainForeignScan")
 			));
 	#endif
+
+	if (es->verbose)
+		ExplainPropertyText("Remote query", festate->query, es);
 	
 	#ifdef DEBUG
 		ereport(NOTICE,


### PR DESCRIPTION
There is already a `tdsExplainForeignScan`, but it does nothing.

I think seeing the remote query would make debugging easier.