### PR TITLE
Fix tdsReScanForeignScan to actually work

### DIFF
--- a/tests/tests/postgresql/035_rescan.json
+++ b/tests/tests/postgresql/035_rescan.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "nested loop with foreign scan on the inner side",
+    "server" : {
+        "version" : {
+            "min" : "9.6.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/035_rescan.sql
+++ b/tests/tests/postgresql/035_rescan.sql
@@ -1,0 +1,17 @@
+/* function is expensive so that the optimizer puts the foreign table on the inner side of the netsed loop */
+CREATE FUNCTION @PSCHEMANAME.expensive() RETURNS TABLE (id integer)
+   LANGUAGE sql IMMUTABLE COST 1000000000 ROWS 1 AS
+'SELECT * FROM generate_series(1, 3)';
+
+/* force a nested loop */
+SET enable_hashjoin = off;
+SET enable_mergejoin = off;
+SET enable_material = off;
+
+SELECT * FROM @PSCHEMANAME.expensive()
+   LEFT JOIN @PSCHEMANAME.view_simple
+      USING (id);
+
+RESET enable_hashjoin;
+RESET enable_mergejoin;
+RESET enable_material;

--- a/tests/tests/postgresql/035_rescan.sql
+++ b/tests/tests/postgresql/035_rescan.sql
@@ -8,9 +8,20 @@ SET enable_hashjoin = off;
 SET enable_mergejoin = off;
 SET enable_material = off;
 
-SELECT * FROM @PSCHEMANAME.expensive()
-   LEFT JOIN @PSCHEMANAME.view_simple
+CREATE TEMP TABLE results (id integer, data text);
+
+INSERT INTO results
+SELECT id, v.data FROM @PSCHEMANAME.expensive() AS f
+   LEFT JOIN @PSCHEMANAME.view_simple AS v
       USING (id);
+
+/* results.data should not be NULL */
+DO $$BEGIN
+   IF EXISTS (SELECT 1 FROM results WHERE data IS NULL)
+   THEN
+      RAISE EXCEPTION 'bad results from query';
+   END IF;
+END;$$;
 
 RESET enable_hashjoin;
 RESET enable_mergejoin;


### PR DESCRIPTION
The implementation of that function was left empty, but that
can lead to wrong query results: If the foreign scan is on
the inner side of a nested loop join, the order of function
calls is as follows:

tdsBeginForeignScan
tdsIterateForeignScan  (until done)
tdsReScanForeignScan   (prepare for second loop iteration)
tdsIterateForeignScan  (until done)
...                    (repeat the last two for each loop)
tdsEndForeignScan

Since "tdsReScanForeignScan" didn't do anything, the second
and all following scans will not return any rows, since the
result set is already exhausted.

This leads to wrong query results.

To fix, consume any remaining rows and reset the state.