### PR TITLE
Do not pass dummy relabeling to foreign server

### DIFF
--- a/src/deparse.c
+++ b/src/deparse.c
@@ -1876,10 +1876,11 @@ static void
 deparseRelabelType(RelabelType *node, deparse_expr_cxt *context)
 {
 	deparseExpr(node->arg, context);
-	if (node->relabelformat != COERCE_IMPLICIT_CAST)
-		appendStringInfo(context->buf, " as %s",
-						 deparse_type_name(node->resulttype,
-										   node->resulttypmod));
+	// Pretty sure this only causes issues.
+	//if (node->relabelformat != COERCE_IMPLICIT_CAST)
+	//	appendStringInfo(context->buf, " as %s",
+	//					 deparse_type_name(node->resulttype,
+	//									   node->resulttypmod));
 }
 
 /*


### PR DESCRIPTION
Dummy relabeling seems to be an internal postgres mechanism to handle casting between two binary-compatible datatypes.

I ran into an issue while using a condition on a varchar column coerced to text.

Without this fix, this postgres query
`SELECT ... FROM ... WHERE this_col_is_a_varchar::text ~~ 'burp%';`

generates something like

`SELECT ... FROM ... WHERE this_vol_is_a_varchar as text like 'burp%';`

which triggers a syntax error. I'm pretty sure passing this relabeling mechanism along is not necessary.

See https://github.com/postgres/postgres/blob/845cad4d51cb12a34ea012dfe58af5ef490384fc/src/include/nodes/primnodes.h#L837