### PR TITLE
Fix fetching blob fields larger then 4096 bytes

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -1556,6 +1556,15 @@ TupleTableSlot* tdsIterateForeignScan(ForeignScanState *node)
 		
 		festate->first = 0;
 
+		/* the following option is needed to get a proper size for blobs */
+		if ((erc = dbsetopt(festate->dbproc, DBTEXTSIZE, "2147483647", -1)) == FAIL)
+		{
+			ereport(WARNING,
+				(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+					errmsg("Failed to set DBTEXTLIMIT server option, blob sizes may be truncated!")
+				));
+		}
+
 		if ((erc = dbcmd(festate->dbproc, festate->query)) == FAIL)
 		{
 			ereport(ERROR,


### PR DESCRIPTION
Blob fields was truncated to 4096 because dbdatlen() was returning
incorrect size without TEXTSIZE server option set properly.
This commit fixes this problem, so the blobs are properly fetched
and converted to PostgreSQL 'bytea' type column.

Fixes #81