### PR TITLE
Allow use_remote_estimate to be set to 0.

### DIFF
--- a/src/options.c
+++ b/src/options.c
@@ -502,7 +502,7 @@ void tdsGetForeignServerTableOptions(List *options_list, TdsFdwOptionSet *option
 		
 		else if (strcmp(def->defname, "use_remote_estimate") == 0)
 		{
-			if (option_set->use_remote_estimate)
+			if (option_set->use_remote_estimate != -1)
 				ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
 						errmsg("Redundant option: use_remote_estimate (%s)", defGetString(def))
@@ -776,7 +776,7 @@ void tdsSetDefaultOptions(TdsFdwOptionSet *option_set)
 		#endif
 	}
 	
-	if (!option_set->use_remote_estimate)
+	if (option_set->use_remote_estimate == -1)
 	{
 		option_set->use_remote_estimate = DEFAULT_USE_REMOTE_ESTIMATE;
 		
@@ -872,6 +872,14 @@ void tdsValidateForeignTableOptionSet(TdsFdwOptionSet *option_set)
 			));
 	}
 
+    /* Check option ranges */
+    if (option_set->use_remote_estimate < 0 || option_set->use_remote_estimate > 1)
+    {
+		ereport(ERROR,
+			(errcode(ERRCODE_SYNTAX_ERROR),
+				errmsg("Invalid value for use_remote_estimate: %d", option_set->use_remote_estimate)
+			));
+    }
 	#ifdef DEBUG
 		ereport(NOTICE,
 			(errmsg("----> finishing tdsValidateForeignTableOptionSet")
@@ -931,7 +939,7 @@ void tdsOptionSetInit(TdsFdwOptionSet* option_set)
 	option_set->table_name = NULL;
 	option_set->row_estimate_method = NULL;
 	option_set->match_column_names = DEFAULT_MATCH_COLUMN_NAMES;
-	option_set->use_remote_estimate = 0;
+	option_set->use_remote_estimate = -1;
 	option_set->fdw_startup_cost = 0;
 	option_set->fdw_tuple_cost = 0;
 	option_set->local_tuple_estimate = 0;

--- a/src/options.c
+++ b/src/options.c
@@ -127,6 +127,7 @@ void tdsValidateOptions(List *options_list, Oid context, TdsFdwOptionSet* option
 	else if (context == ForeignTableRelationId)
 	{
 		tdsGetForeignTableOptions(options_list, option_set);
+		tdsSetDefaultOptions(option_set);
 		tdsValidateForeignTableOptionSet(option_set);
 	}
 	


### PR DESCRIPTION
Previously, the code applying default settings would assume the option was unset, and set the default value of 1. We use a sentinel value instead, which allows us to detect this case separately.