### PR TITLE
add upgrade route from 2.0.1 to 2.0.3 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ EXTVERSION = $(shell grep default_version $(EXTENSION).control | sed -e "s/defau
 
 DOCS         = README.${EXTENSION}.md
 
-DATA = sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = tds_fdw--2.0.1--2.0.2.sql  tds_fdw--2.0.2--2.0.3.sql sql/$(EXTENSION)--$(EXTVERSION).sql
 
 PG_CONFIG    = pg_config
 

--- a/tds_fdw--2.0.1--2.0.2.sql
+++ b/tds_fdw--2.0.1--2.0.2.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION tds_fdw UPDATE TO '2.0.2'" to load this file. \quit

--- a/tds_fdw--2.0.2--2.0.3.sql
+++ b/tds_fdw--2.0.2--2.0.3.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION tds_fdw UPDATE TO '2.0.3'" to load this file. \quit


### PR DESCRIPTION
Fix for the ability to upgrade from version 2.0.1 to 2.0.3
Update from version 1.0.0 intentionally skipped