### PR TITLE
Support server-side ANSI settings

### DIFF
--- a/ForeignServerCreation.md
+++ b/ForeignServerCreation.md
@@ -102,8 +102,7 @@ A cost that is used to represent the overhead of fetching rows from this server 
 
 Required: No
 
-Setting this to "true" will enable the following server-side settings after a successful connection
-to the foreign server:
+The default is "false". Setting this to "true" will enable the following server-side settings after a successful connection to the foreign server:
 
 	* CONCAT_NULLS_YIELDS_NULL ON
 	* ANSI_NULLS ON

--- a/ForeignServerCreation.md
+++ b/ForeignServerCreation.md
@@ -109,12 +109,14 @@ The default is "false". Setting this to "true" will enable the following server-
 	* ANSI_WARNINGS ON
 	* QUOTED_IDENTIFIER ON
 	* ANSI_PADDING ON
+	* ANSI_NULL_DFLT_ON ON
 
 Those parameters in summary are comparable to the SQL Server option *ANSI_DEFAULTS*. In contrast, *ansi_mode* currently does not activate the following options:
 
 	* CURSOR_CLOSE_ON_COMMIT
 	* IMPLICIT_TRANSACTIONS
-	* ANSI_NULL_DFLT_ON
+
+This follows the behavior of the native ODBC and OLEDB driver for SQL Servers, which explicitly turn them `OFF` if not configured otherwise.
 
 #### Foreign table parameters accepted in server definition:
 

--- a/ForeignServerCreation.md
+++ b/ForeignServerCreation.md
@@ -98,7 +98,7 @@ Required: No
 
 A cost that is used to represent the overhead of fetching rows from this server used in query planning.
 
-* *ansi_mode*
+* *sqlserver_ansi_mode*
 
 Required: No
 
@@ -111,7 +111,7 @@ The default is "false". Setting this to "true" will enable the following server-
 	* ANSI_PADDING ON
 	* ANSI_NULL_DFLT_ON ON
 
-Those parameters in summary are comparable to the SQL Server option *ANSI_DEFAULTS*. In contrast, *ansi_mode* currently does not activate the following options:
+Those parameters in summary are comparable to the SQL Server option *ANSI_DEFAULTS*. In contrast, *sqlserver_ansi_mode* currently does not activate the following options:
 
 	* CURSOR_CLOSE_ON_COMMIT
 	* IMPLICIT_TRANSACTIONS

--- a/ForeignServerCreation.md
+++ b/ForeignServerCreation.md
@@ -98,6 +98,25 @@ Required: No
 
 A cost that is used to represent the overhead of fetching rows from this server used in query planning.
 
+* *ansi_mode*
+
+Required: No
+
+Setting this to "true" will enable the following server-side settings after a successful connection
+to the foreign server:
+
+	* CONCAT_NULLS_YIELDS_NULL ON
+	* ANSI_NULLS ON
+	* ANSI_WARNINGS ON
+	* QUOTED_IDENTIFIER ON
+	* ANSI_PADDING ON
+
+Those parameters in summary are comparable to the SQL Server option *ANSI_DEFAULTS*. In contrast, *ansi_mode* currently does not activate the following options:
+
+	* CURSOR_CLOSE_ON_COMMIT
+	* IMPLICIT_TRANSACTIONS
+	* ANSI_NULL_DFLT_ON
+
 #### Foreign table parameters accepted in server definition:
 
 Some foreign table options can also be set at the server level. Those include:

--- a/include/options.h
+++ b/include/options.h
@@ -30,6 +30,7 @@ typedef struct TdsFdwOptionSet
 	char *schema_name;
 	char *table_name;
 	char* row_estimate_method;
+	bool ansi_mode;
 	int match_column_names;
 	int use_remote_estimate;
 	int fdw_startup_cost;

--- a/include/options.h
+++ b/include/options.h
@@ -30,7 +30,7 @@ typedef struct TdsFdwOptionSet
 	char *schema_name;
 	char *table_name;
 	char* row_estimate_method;
-	bool ansi_mode;
+	bool sqlserver_ansi_mode;
 	int match_column_names;
 	int use_remote_estimate;
 	int fdw_startup_cost;

--- a/src/options.c
+++ b/src/options.c
@@ -56,7 +56,7 @@ static struct TdsFdwOption valid_options[] =
 	{ "port",					ForeignServerRelationId },
 	{ "database",				ForeignServerRelationId },
 	{ "dbuse",					ForeignServerRelationId },
-    { "ansi_mode",              ForeignServerRelationId },
+    { "sqlserver_ansi_mode",    ForeignServerRelationId },
 	{ "tds_version",			ForeignServerRelationId },
 	{ "msg_handler",			ForeignServerRelationId },
 	{ "row_estimate_method",	ForeignServerRelationId },
@@ -318,15 +318,15 @@ void tdsGetForeignServerOptions(List *options_list, TdsFdwOptionSet *option_set)
 			option_set->dbuse = atoi(defGetString(def));	
 		}	
 
-		else if(strcmp(def->defname, "ansi_mode") == 0)
+		else if(strcmp(def->defname, "sqlserver_ansi_mode") == 0)
 		{
-			if (option_set->ansi_mode)
+			if (option_set->sqlserver_ansi_mode)
 				ereport(ERROR,
 					(errcode(ERRCODE_SYNTAX_ERROR),
-						errmsg("Redundant option: ansi_mode (%s)", defGetBoolean(def))
+						errmsg("Redundant option: sqlserver_ansi_mode (%s)", defGetBoolean(def))
 					));
 
-			option_set->ansi_mode = defGetBoolean(def);
+			option_set->sqlserver_ansi_mode = defGetBoolean(def);
 		}
 
 		else if (strcmp(def->defname, "tds_version") == 0)
@@ -943,7 +943,7 @@ void tdsOptionSetInit(TdsFdwOptionSet* option_set)
 	option_set->port = 0;
 	option_set->database = NULL;
 	option_set->dbuse = 0;
-	option_set->ansi_mode = false;
+	option_set->sqlserver_ansi_mode = false;
 	option_set->tds_version = NULL;
 	option_set->msg_handler = NULL;
 	option_set->username = NULL;

--- a/src/options.c
+++ b/src/options.c
@@ -56,6 +56,7 @@ static struct TdsFdwOption valid_options[] =
 	{ "port",					ForeignServerRelationId },
 	{ "database",				ForeignServerRelationId },
 	{ "dbuse",					ForeignServerRelationId },
+    { "ansi_mode",              ForeignServerRelationId },
 	{ "tds_version",			ForeignServerRelationId },
 	{ "msg_handler",			ForeignServerRelationId },
 	{ "row_estimate_method",	ForeignServerRelationId },
@@ -316,6 +317,17 @@ void tdsGetForeignServerOptions(List *options_list, TdsFdwOptionSet *option_set)
 					
 			option_set->dbuse = atoi(defGetString(def));	
 		}	
+
+		else if(strcmp(def->defname, "ansi_mode") == 0)
+		{
+			if (option_set->ansi_mode)
+				ereport(ERROR,
+					(errcode(ERRCODE_SYNTAX_ERROR),
+						errmsg("Redundant option: ansi_mode (%s)", defGetBoolean(def))
+					));
+
+			option_set->ansi_mode = defGetBoolean(def);
+		}
 
 		else if (strcmp(def->defname, "tds_version") == 0)
 		{
@@ -931,6 +943,7 @@ void tdsOptionSetInit(TdsFdwOptionSet* option_set)
 	option_set->port = 0;
 	option_set->database = NULL;
 	option_set->dbuse = 0;
+	option_set->ansi_mode = false;
 	option_set->tds_version = NULL;
 	option_set->msg_handler = NULL;
 	option_set->username = NULL;

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -430,124 +430,32 @@ void tdsBuildForeignQuery(PlannerInfo *root, RelOptInfo *baserel, TdsFdwOptionSe
 /* helper function to set ANSI options */
 void tdsSetAnsiMode(DBPROCESS **dbproc)
 {
-	char *set_concat_null_yields_null_query = "SET CONCAT_NULL_YIELDS_NULL ON;";
-	char *set_ansi_nulls_query = "SET ANSI_NULLS ON;";
-	char *set_ansi_warnings_query = "SET ANSI_WARNINGS ON;";
-	char *set_quoted_identifier_query = "SET QUOTED_IDENTIFIER ON;";
-	char *set_ansi_padding_query = "SET ANSI_PADDING ON;";
+	char *set_ansi_options_query = "SET CONCAT_NULL_YIELDS_NULL, "
+		"ANSI_NULLS, "
+		"ANSI_WARNINGS, "
+		"QUOTED_IDENTIFIER, "
+		"ANSI_PADDING, "
+		"ANSI_NULL_DFLT_ON ON";
 	RETCODE erc;
 
-	/* CONCAT_NULLS_YIELDS_NULL setting */
+    elog(DEBUG3, "tds_fdw: enabling ansi settings");
 
-    elog(DEBUG3, "setting CONCAT_NULL_YIELDS_NULL");
-
-	if ((erc = dbcmd(*dbproc, set_concat_null_yields_null_query)) == FAIL)
+	if ((erc = dbcmd(*dbproc, set_ansi_options_query)) == FAIL)
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_concat_null_yields_null_query)
+				errmsg("Failed to set %s", set_ansi_options_query)
 			));
 	}
 
 	ereport(DEBUG3,
-		(errmsg("tds_fdw: Executing the query")
-		));
+			(errmsg("tds_fdw: Executing the query \"%s\"", set_ansi_options_query)));
 
 	if ((erc = dbsqlexec(*dbproc)) == FAIL)
 	{
 		ereport(ERROR,
 			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to execute query %s", set_concat_null_yields_null_query)
-			));
-	}
-
-    elog(DEBUG3, "setting ANSI_NULLS");
-
-	/* ANSI_NULLS setting */
-
-	if ((erc = dbcmd(*dbproc, set_ansi_nulls_query)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_nulls_query)
-			));
-	}
-
-	ereport(DEBUG3,
-		(errmsg("tds_fdw: Executing the query")
-		));
-
-	if ((erc = dbsqlexec(*dbproc)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to execute query %s", set_ansi_nulls_query)
-			));
-	}
-
-	/* ANSI_WARNINGS setting */
-
-	if ((erc = dbcmd(*dbproc, set_ansi_warnings_query)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_warnings_query)
-			));
-	}
-
-	ereport(DEBUG3,
-		(errmsg("tds_fdw: Executing the query")
-		));
-
-	if ((erc = dbsqlexec(*dbproc)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to execute query %s", set_ansi_warnings_query)
-			));
-	}
-
-	/* QUOTED_IDENTIFIER setting */
-
-	if ((erc = dbcmd(*dbproc, set_quoted_identifier_query)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_quoted_identifier_query)
-			));
-	}
-
-	ereport(DEBUG3,
-		(errmsg("tds_fdw: Executing the query")
-		));
-
-	if ((erc = dbsqlexec(*dbproc)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to execute query %s", set_quoted_identifier_query)
-			));
-	}
-
-	/* ANSI_PADDING setting */
-
-	if ((erc = dbcmd(*dbproc, set_ansi_padding_query)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_padding_query)
-			));
-	}
-
-	ereport(DEBUG3,
-		(errmsg("tds_fdw: Executing the query")
-		));
-
-	if ((erc = dbsqlexec(*dbproc)) == FAIL)
-	{
-		ereport(ERROR,
-			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
-				errmsg("Failed to execute query %s", set_ansi_padding_query)
+				errmsg("Failed to execute query %s", set_ansi_options_query)
 			));
 	}
 

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -111,6 +111,12 @@ static int tds_chkintr_func(void* vdbproc);
 static int tds_hndlintr_func(void* vdbproc);
 
 /*
+ * Internal helper to set ANSI compatible server-side settings in
+ * case foreign server was configured with ansi_mode 'true'.
+ */
+static void tdsSetAnsiMode(DBPROCESS **dbproc);
+
+/*
  * Indexes of FDW-private information stored in fdw_private lists.
  *
  * We store various information in ForeignScan.fdw_private to pass it from

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -111,10 +111,10 @@ static int tds_chkintr_func(void* vdbproc);
 static int tds_hndlintr_func(void* vdbproc);
 
 /*
- * Internal helper to set ANSI compatible server-side settings in
- * case foreign server was configured with ansi_mode 'true'.
+ * Internal helper to set ANSI compatible server-side settings for SQL Server
+ * in case foreign server was configured with sqlserver_ansi_mode 'true'.
  */
-static void tdsSetAnsiMode(DBPROCESS **dbproc);
+static void tdsSetSqlServerAnsiMode(DBPROCESS **dbproc);
 
 /*
  * Indexes of FDW-private information stored in fdw_private lists.
@@ -428,7 +428,7 @@ void tdsBuildForeignQuery(PlannerInfo *root, RelOptInfo *baserel, TdsFdwOptionSe
 }
 
 /* helper function to set ANSI options */
-void tdsSetAnsiMode(DBPROCESS **dbproc)
+void tdsSetSqlServerAnsiMode(DBPROCESS **dbproc)
 {
 	char *set_ansi_options_query = "SET CONCAT_NULL_YIELDS_NULL, "
 		"ANSI_NULLS, "
@@ -668,8 +668,8 @@ int tdsSetupConnection(TdsFdwOptionSet* option_set, LOGINREC *login, DBPROCESS *
 	}
 
 	/* Enable ANSI mode if requested */
-	if (option_set->ansi_mode) {
-		tdsSetAnsiMode(dbproc);
+	if (option_set->sqlserver_ansi_mode) {
+		tdsSetSqlServerAnsiMode(dbproc);
 	}
 	
 	#ifdef DEBUG

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -421,6 +421,131 @@ void tdsBuildForeignQuery(PlannerInfo *root, RelOptInfo *baserel, TdsFdwOptionSe
 	#endif	
 }
 
+/* helper function to set ANSI options */
+void tdsSetAnsiMode(DBPROCESS **dbproc)
+{
+	char *set_concat_null_yields_null_query = "SET CONCAT_NULL_YIELDS_NULL ON;";
+	char *set_ansi_nulls_query = "SET ANSI_NULLS ON;";
+	char *set_ansi_warnings_query = "SET ANSI_WARNINGS ON;";
+	char *set_quoted_identifier_query = "SET QUOTED_IDENTIFIER ON;";
+	char *set_ansi_padding_query = "SET ANSI_PADDING ON;";
+	RETCODE erc;
+
+	/* CONCAT_NULLS_YIELDS_NULL setting */
+
+    elog(DEBUG3, "setting CONCAT_NULL_YIELDS_NULL");
+
+	if ((erc = dbcmd(*dbproc, set_concat_null_yields_null_query)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_concat_null_yields_null_query)
+			));
+	}
+
+	ereport(DEBUG3,
+		(errmsg("tds_fdw: Executing the query")
+		));
+
+	if ((erc = dbsqlexec(*dbproc)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to execute query %s", set_concat_null_yields_null_query)
+			));
+	}
+
+    elog(DEBUG3, "setting ANSI_NULLS");
+
+	/* ANSI_NULLS setting */
+
+	if ((erc = dbcmd(*dbproc, set_ansi_nulls_query)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_nulls_query)
+			));
+	}
+
+	ereport(DEBUG3,
+		(errmsg("tds_fdw: Executing the query")
+		));
+
+	if ((erc = dbsqlexec(*dbproc)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to execute query %s", set_ansi_nulls_query)
+			));
+	}
+
+	/* ANSI_WARNINGS setting */
+
+	if ((erc = dbcmd(*dbproc, set_ansi_warnings_query)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_warnings_query)
+			));
+	}
+
+	ereport(DEBUG3,
+		(errmsg("tds_fdw: Executing the query")
+		));
+
+	if ((erc = dbsqlexec(*dbproc)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to execute query %s", set_ansi_warnings_query)
+			));
+	}
+
+	/* QUOTED_IDENTIFIER setting */
+
+	if ((erc = dbcmd(*dbproc, set_quoted_identifier_query)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_quoted_identifier_query)
+			));
+	}
+
+	ereport(DEBUG3,
+		(errmsg("tds_fdw: Executing the query")
+		));
+
+	if ((erc = dbsqlexec(*dbproc)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to execute query %s", set_quoted_identifier_query)
+			));
+	}
+
+	/* ANSI_PADDING setting */
+
+	if ((erc = dbcmd(*dbproc, set_ansi_padding_query)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to set CONCAT_NULL_YIELDS_NULL to %s", set_ansi_padding_query)
+			));
+	}
+
+	ereport(DEBUG3,
+		(errmsg("tds_fdw: Executing the query")
+		));
+
+	if ((erc = dbsqlexec(*dbproc)) == FAIL)
+	{
+		ereport(ERROR,
+			(errcode(ERRCODE_FDW_UNABLE_TO_CREATE_EXECUTION),
+				errmsg("Failed to execute query %s", set_ansi_padding_query)
+			));
+	}
+
+}
 
 /* set up connection */
 
@@ -627,13 +752,18 @@ int tdsSetupConnection(TdsFdwOptionSet* option_set, LOGINREC *login, DBPROCESS *
 			(errmsg("tds_fdw: Selected database")
 			));
 	}
+
+	/* Enable ANSI mode if requested */
+	if (option_set->ansi_mode) {
+		tdsSetAnsiMode(dbproc);
+	}
 	
 	#ifdef DEBUG
 		ereport(NOTICE,
 			(errmsg("----> finishing tdsSetupConnection")
 			));
 	#endif	
-	
+
 	return 0;
 }
 
@@ -645,7 +775,7 @@ double tdsGetRowCountShowPlanAll(TdsFdwOptionSet* option_set, LOGINREC *login, D
 	char* show_plan_query = "SET SHOWPLAN_ALL ON";
 	char* show_plan_query_off = "SET SHOWPLAN_ALL OFF";
 	
-	#ifdef DEBUG
+    #ifdef DEBUG
 		ereport(NOTICE,
 			(errmsg("----> starting tdsGetRowCountShowPlanAll")
 			));


### PR DESCRIPTION
Specific feature in SQL Server forces us to set ANSI-compliant options during database sessions.

One example are XML features, especially when exposed when using views like this example:

SQL Server:

````sql
CREATE VIEW bernd.test_xml AS 
SELECT CAST('<name>Bernd</name>' as xml).exist('/name') AS xml_val;
````

Map/Import the view as a `FOREIGN TABLE` in PostgreSQL:

````sql
import foreign schema bernd LIMIT TO(test_xml) from server sqlserver_ubuntu INTO sqlserver ;
IMPORT FOREIGN SCHEMA
````

The view gets correctly mapped (the `exist()` XML function returns `1` to indicate it found a matching key):

````
\d sqlserver.test_xml 
                      Foreign table "sqlserver.test_xml"
 Column  │   Type   │ Collation │ Nullable │ Default │       FDW options       
─────────┼──────────┼───────────┼──────────┼─────────┼─────────────────────────
 xml_val │ smallint │           │          │         │ (column_name 'xml_val')
Server: sqlserver_ubuntu
FDW options: (schema_name 'bernd', table_name 'test_xml')
````

Though a `SELECT` from this view with its single column returning the result of the `XMLQuery` yields the following `ERROR` (msg_handler set to `notice` so the details of the error can be seen):

````sql
SELECT * FROM sqlserver.test_xml ;

NOTICE:  DB-Library notice: Msg #: 5701, Msg state: 2, Msg: Changed database context to 'bernd'., Server: 9327c78cf76b, Process: , Line: 1, Level: 0
NOTICE:  DB-Library notice: Msg #: 5703, Msg state: 1, Msg: Changed language setting to us_english., Server: 9327c78cf76b, Process: , Line: 1, Level: 0
NOTICE:  DB-Library notice: Msg #: 1934, Msg state: 1, Msg: SELECT failed because the following SET options have incorrect settings: 'ANSI_NULLS, QUOTED_IDENTIFIER, CONCAT_NULL_YIELDS_NULL, ANSI_WARNINGS, ANSI_PADDING'. Verify that SET options are correct for use with indexed views and/or indexes on computed columns and/or filtered indexes and/or query notifications and/or XML data type methods and/or spatial index operations., Server: 9327c78cf76b, Process: , Line: 1, Level: 16
ERROR:  DB-Library error: DB #: 20018, DB Msg: General SQL Server error: Check messages from the SQL Server, OS #: -1, OS Msg: , Level: 16
````

SQL Server forces `ANSI` compliant settings when using specific functions/features, like documented here (and the notice message also gives a hint regarding the `XML` datatype used):

https://learn.microsoft.com/en-us/sql/t-sql/statements/set-ansi-defaults-transact-sql?view=sql-server-ver16

There is a single `ANSI_DEFAULTS` setting, which can be used to make such constructs usable with TDS clients, according to the documentation it aggregates the following settings:

- `ANSI_NULLS`
- `ANSI_NULL_DFLT_ON`
- `ANSI_PADDING`
- `QUOTED_IDENTIFIER`
- `ANSI_WARNINGS`
- `CURSOR_CLOSE_ON_COMMIT`
- `IMPLICIT_TRANSACTIONS`

I've decided _not_ to use `ANSI_DEFAULTS` directly, since i am not sure `CURSOR_CLOSE_ON_COMMIT` and especially `IMPLICIT_TRANSACTIONS` is something we want in `tds_fdw`. In fact, according to the documentation above, the native ODBC and OLEDB drivers are setting this two parameters back to `OFF` by default after having set `ANSI_DEFAULTS ON`. 

`ANSI_DEFAULTS ON` also doesn't set `CONCAT_NULL_YIELD_NULL`, too. So i decided to set all required `ANSI` parameters explicitly by the new helper function `tdsSetAnsiMode()`. Please note that SQL Server will force `CONCAT_NULL_YIELDS_NULL ON` in future releases, documented here:

https://learn.microsoft.com/en-us/sql/t-sql/statements/set-concat-null-yields-null-transact-sql?view=sql-server-ver16

So after all i've decided to set all options explicitly as we need.

The parameters need to be set at connection start, so i made it a new foreign server option `sqlserver_ansi_mode`, used e.g. like this:

````sql
CREATE SERVER sqlserver_ubuntu FOREIGN DATA WRAPPER tds_fdw OPTIONS (
    database 'bernd',
    port '1433',
    servername 'sqlserver.somewhere',
    sqlserver_ansi_mode 'true',
    tds_version '7.4'
);
````

First i used to name it `ansi_mode`, but research revealed that Sybase seems to have a completely different behavior here, thus i renamed it to `sqlserver_ansi_mode` to reflect its purpose better. Please see the updated documentation in `ForeignServerCreation.md`.

Since these properties are session specific i am not sure it make sense to make them available on table-level, too.

With all this in place, selecting such views just works:

````sql
ALTER SERVER sqlserver OPTIONS(ADD sqlserver_ansi_mode 'true');
ALTER SERVER

SELECT * FROM sqlserver.test_xml ;
NOTICE:  tds_fdw: Query executed correctly
NOTICE:  tds_fdw: Getting results
 xml_val 
─────────
       1
(1 row)
````
