### PR TITLE
Update RHEL and Clones compilation instructions

### DIFF
--- a/InstallRHELandClones.md
+++ b/InstallRHELandClones.md
@@ -7,7 +7,7 @@
 
 ## Installing on RHEL and Clones such as CentOS, Rocky Linux, AlmaLinux or Oracle
 
-This document will show how to install tds_fdw on Rocky Linux 8.5. RHEL distributions should be similar.
+This document will show how to install tds_fdw on Rocky Linux 8.9. RHEL distributions should be similar.
 
 NOTE: For the sake of simplicity, we will use `yum` as it works as an alias for `dnf` on newer distributions.
 
@@ -16,20 +16,6 @@ NOTE: For the sake of simplicity, we will use `yum` as it works as an alias for 
 #### PostgreSQL
 
 If you need to install PostgreSQL, do so by following the [RHEL installation instructions](https://www.postgresql.org/download/linux/redhat/).
-
-Here is an extract of the instructions:
-
-Only for RHEL 8 and clones such as Rocky Linux 8:
-```bash
-sudo sudo dnf -qy module disable postgresql # Not required for RHEL8 and clones
-```
-
-Install the PostgreSQL repository and packages:
-
-```bash
-sudo rpm -i https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-sudo yum install postgresql11 postgresql11-server postgresql11-libs postgresql11-devel
-```
 
 #### tds_fdw
 
@@ -53,33 +39,29 @@ sudo yum install tds_fdw11.x86_64
 
 If you need to install PostgreSQL, do so by following the [RHEL installation instructions](https://www.postgresql.org/download/linux/redhat/).
 
-Here is an extract of the instructions:
+Make sure that, besides `postgresqlXX-server`, `postgresqlXX-devel` is installed as well
 
-Only for RHEL 8 and clones such as Rocky Linux 8:
-```bash
-sudo sudo dnf -qy module disable postgresql # Not required for RHEL8 and clones
-```
-
-Install the PostgreSQL repository and packages:
-
-```bash
-sudo rpm -i https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm
-sudo yum install postgresql11 postgresql11-server postgresql11-libs postgresql11-devel
-```
+You need to enable the PowerTools repository for RHEL8 and clones, or the CBR repository for RHEL9 and clones.
 
 #### Install FreeTDS devel and build dependencies
 
 The TDS foreign data wrapper requires a library that implements the DB-Library interface,
 such as [FreeTDS](http://www.freetds.org).
 
-**NOTE:** In CentOS, you need the [EPEL repository installed](https://fedoraproject.org/wiki/EPEL) to install FreeTDS
+**NOTE:** You need the [EPEL repository installed](https://fedoraproject.org/wiki/EPEL) to install FreeTDS
 
 ```bash
 sudo yum install epel-release
 sudo yum install freetds-devel
 ```
 
-## IMPORTANT: CentOS7/Oracle7 and PostgreSQL >= 11
+Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
+
+```bash
+sudo yum install clang llvm make redhat-rpm-config wget
+```
+
+#### IMPORTANT: CentOS7/Oracle7 and PostgreSQL >= 11
 
 When using the official PostgreSQL packages from postgresql.org, JIT with bitcode is enabled by default and will require llvm5 and `clang` from LLVM5 installed at `/opt/rh/llvm-toolset-7/root/usr/bin/clang` to be able to compile.
 
@@ -89,12 +71,6 @@ You can easily do it with the following commands:
 
 ```bash
 sudo yum install centos-release-scl
-```
-
-Some other dependencies are also needed to install PostgreSQL and then compile tds_fdw:
-
-```bash
-sudo yum install gcc make wget
 ```
 
 ##### Build from release package


### PR DESCRIPTION
The [CI started failing for Rocky Linux 8 on August 9th](https://jenkins.juliogonzalez.es/job/tds_fdw-build/3236/console) as `/usr/bin/clang` was not installed. I tried installing from scratch and more packages were missing besides `clang` (`llvm` and `redhat-rpm-config`, this one at least on containers).

Since `gcc` is a requirement for `clang`,  we don't need to specify it.

So this PR is basically implementing at the doc, the following changes at the images: https://github.com/tds-fdw/ci-setup/compare/b3d2ac6ec21bf899c6ea56d6b6aed47e8727cb7a...399c0df2073872242404818b2dcdae3c7538ab65

With that, the extension builds and the test are able to run: https://jenkins.juliogonzalez.es/view/tds_fdw-jobs/job/tds_fdw-build/3243/

I am not sure why this is suddenly happening, I guess it's a change on the dependency tree, maybe on PostgreSQL itself not requiring `clang` and `lvm` for the devel package.

Besides this, I removed the instructions about how to install PostgreSQL, as the official doc that is linked does a perfect job, with a form to pick architecture, platform, etc, and this way we don't need to worry about using the right repositories or GPG keys.