### PR TITLE
Update tds_fdw.c - money to decimal

### DIFF
--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -3437,9 +3437,10 @@ tdsImportSqlServerSchema(ImportForeignSchemaStmt *stmt, DBPROCESS  *dbproc,
 							appendStringInfo(&buf, " numeric(%d, %d)",
 											 numeric_precision, numeric_scale);
 					}
-					else if (strcmp(data_type, "money") == 0 ||
-							 strcmp(data_type, "smallmoney") == 0)
-						appendStringInfoString(&buf, " money");
+					 else if (strcmp(data_type, "money") == 0)
+					     appendStringInfoString(&buf, " numeric(19,4)");
+					  else if (strcmp(data_type, "smallmoney") == 0)
+					      appendStringInfoString(&buf, " numeric(10,4)");
 
 					/* Floating-point types */
 					else if (strcmp(data_type, "float") == 0)


### PR DESCRIPTION
In the current implementation, attempting to select from tables that have fields with the `money` datatype adds commas which break the double type

SELECT * FROM "vadmin_dbo"."accounts" LIMIT 1
Bad value for type double : 10,000,000.00