### PR TITLE
Tests for the money and smallmoney types

### DIFF
--- a/tests/tests/mssql/030_create_money_min_table.json
+++ b/tests/tests/mssql/030_create_money_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with money data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/030_create_money_min_table.sql
+++ b/tests/tests/mssql/030_create_money_min_table.sql
@@ -1,0 +1,9 @@
+IF OBJECT_ID('@SCHEMANAME.money_min', 'U') IS NOT NULL
+        DROP TABLE @SCHEMANAME.money_min;
+
+CREATE TABLE @SCHEMANAME.money_min (
+        id int primary key,
+        value money
+);
+
+INSERT INTO @SCHEMANAME.money_min (id, value) VALUES (1, -922337203685477.5808);

--- a/tests/tests/mssql/031_create_money_max_table.json
+++ b/tests/tests/mssql/031_create_money_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with money data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/031_create_money_max_table.sql
+++ b/tests/tests/mssql/031_create_money_max_table.sql
@@ -1,0 +1,9 @@
+IF OBJECT_ID('@SCHEMANAME.money_max', 'U') IS NOT NULL
+        DROP TABLE @SCHEMANAME.money_max;
+
+CREATE TABLE @SCHEMANAME.money_max (
+        id int primary key,
+        value money
+);
+
+INSERT INTO @SCHEMANAME.money_max (id, value) VALUES (1, 922337203685477.5807);

--- a/tests/tests/mssql/032_create_smallmoney_min_table.json
+++ b/tests/tests/mssql/032_create_smallmoney_min_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with smallmoney data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/032_create_smallmoney_min_table.sql
+++ b/tests/tests/mssql/032_create_smallmoney_min_table.sql
@@ -1,0 +1,9 @@
+IF OBJECT_ID('@SCHEMANAME.smallmoney_min', 'U') IS NOT NULL
+        DROP TABLE @SCHEMANAME.smallmoney_min;
+
+CREATE TABLE @SCHEMANAME.smallmoney_min (
+        id int primary key,
+        value smallmoney
+);
+
+INSERT INTO @SCHEMANAME.smallmoney_min (id, value) VALUES (1, -214748.3648);

--- a/tests/tests/mssql/033_create_smallmoney_max_table.json
+++ b/tests/tests/mssql/033_create_smallmoney_max_table.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "table creation with smallmoney data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "7.0.623",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/mssql/033_create_smallmoney_max_table.sql
+++ b/tests/tests/mssql/033_create_smallmoney_max_table.sql
@@ -1,0 +1,9 @@
+IF OBJECT_ID('@SCHEMANAME.smallmoney_max', 'U') IS NOT NULL
+        DROP TABLE @SCHEMANAME.smallmoney_max;
+
+CREATE TABLE @SCHEMANAME.smallmoney_max (
+        id int primary key,
+        value smallmoney
+);
+
+INSERT INTO @SCHEMANAME.smallmoney_max (id, value) VALUES (1, 214748.3647);

--- a/tests/tests/postgresql/036_moneymin.json
+++ b/tests/tests/postgresql/036_moneymin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "money data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/036_moneymin.sql
+++ b/tests/tests/postgresql/036_moneymin.sql
@@ -1,0 +1,10 @@
+DROP FOREIGN TABLE IF EXISTS @PSCHEMANAME.money_min;
+
+CREATE FOREIGN TABLE @PSCHEMANAME.money_min (
+        id int,
+        value money
+)
+        SERVER mssql_svr
+        OPTIONS (table '@MSCHEMANAME.money_min', row_estimate_method 'showplan_all');
+
+SELECT * FROM @PSCHEMANAME.money_min;

--- a/tests/tests/postgresql/037_moneymax.json
+++ b/tests/tests/postgresql/037_moneymax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "money data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/037_moneymax.sql
+++ b/tests/tests/postgresql/037_moneymax.sql
@@ -1,0 +1,10 @@
+DROP FOREIGN TABLE IF EXISTS @PSCHEMANAME.money_max;
+
+CREATE FOREIGN TABLE @PSCHEMANAME.money_max (
+        id int,
+        value money
+)
+        SERVER mssql_svr
+        OPTIONS (table '@MSCHEMANAME.money_max', row_estimate_method 'showplan_all');
+
+SELECT * FROM @PSCHEMANAME.money_max;

--- a/tests/tests/postgresql/038_smallmoneymin.json
+++ b/tests/tests/postgresql/038_smallmoneymin.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "smallmoney data type, minimum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/038_smallmoneymin.sql
+++ b/tests/tests/postgresql/038_smallmoneymin.sql
@@ -1,0 +1,11 @@
+DROP FOREIGN TABLE IF EXISTS @PSCHEMANAME.smallmoney_min;
+
+-- There is no smallmoney in PostgreSQL so we map it as the 8bit money type
+CREATE FOREIGN TABLE @PSCHEMANAME.smallmoney_min (
+        id int,
+        value money
+)
+        SERVER mssql_svr
+        OPTIONS (table '@MSCHEMANAME.smallmoney_min', row_estimate_method 'showplan_all');
+
+SELECT * FROM @PSCHEMANAME.smallmoney_min;

--- a/tests/tests/postgresql/039_smallmoneymax.json
+++ b/tests/tests/postgresql/039_smallmoneymax.json
@@ -1,0 +1,9 @@
+{
+    "test_desc" : "smallmoney data type, maximum value",
+    "server" : {
+        "version" : {
+            "min" : "9.2.0",
+            "max" : ""
+        }
+    }
+}

--- a/tests/tests/postgresql/039_smallmoneymax.sql
+++ b/tests/tests/postgresql/039_smallmoneymax.sql
@@ -1,0 +1,11 @@
+DROP FOREIGN TABLE IF EXISTS @PSCHEMANAME.smallmoney_max;
+
+-- There is no smallmoney in PostgreSQL so we map it as the 8bit money type
+CREATE FOREIGN TABLE @PSCHEMANAME.smallmoney_max (
+        id int,
+        value money
+)
+        SERVER mssql_svr
+        OPTIONS (table '@MSCHEMANAME.smallmoney_max', row_estimate_method 'showplan_all');
+
+SELECT * FROM @PSCHEMANAME.smallmoney_max;


### PR DESCRIPTION
- Fixes https://github.com/tds-fdw/tds_fdw/issues/375
- Hopefully completes https://github.com/tds-fdw/tds_fdw/pull/374

As usual, we text the min and max value for each type. Those are created a separate tables at MSSQL, then we map them as foreign tables at PostgreSQL and we try to read the values.

https://github.com/tds-fdw/tds_fdw/pull/374 does a conversion to decimal and seems that works, even when we map directly to money.

I see @Daemach tried to use the automated mapping, so not sure if he ever tried to do manual mapping of the data types (so far we don't have a test for this, IIRC).