### PR TITLE
Support PostgreSQL 18

### DIFF
--- a/include/tds_fdw.h
+++ b/include/tds_fdw.h
@@ -24,7 +24,11 @@
 
 #include "postgres.h"
 #include "funcapi.h"
+#if PG_VERSION_NUM < 180000
 #include "commands/explain.h"
+#else
+#include "commands/explain_state.h"
+#endif
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
 

--- a/src/deparse.c
+++ b/src/deparse.c
@@ -2051,7 +2051,11 @@ appendOrderByClause(StringInfo buf, PlannerInfo *root, RelOptInfo *baserel,
 
 		appendStringInfoString(buf, delim);
 		deparseExpr(em_expr, &context);
+#if PG_VERSION_NUM < 180000
 		if (pathkey->pk_strategy == BTLessStrategyNumber)
+#else
+		if (pathkey->pk_cmptype == COMPARE_LT)
+#endif
 			appendStringInfoString(buf, " ASC");
 		else
 			appendStringInfoString(buf, " DESC");

--- a/src/tds_fdw.c
+++ b/src/tds_fdw.c
@@ -37,7 +37,12 @@
 #include "catalog/pg_user_mapping.h"
 #include "catalog/pg_type.h"
 #include "commands/defrem.h"
+#if PG_VERSION_NUM < 180000
 #include "commands/explain.h"
+#else
+#include "commands/explain_format.h"
+#include "commands/explain_state.h"
+#endif
 #include "foreign/fdwapi.h"
 #include "foreign/foreign.h"
 #include "miscadmin.h"
@@ -2617,9 +2622,20 @@ void tdsGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntable
 								   NULL,		/* no outer rel either */
 								   NULL,		/* no extra plan */
 								   NIL);		/* no fdw_private list */
+#elif PG_VERSION_NUM < 180000
+	path = create_foreignscan_path(root, baserel, NULL,
+								   fpinfo->rows,
+								   fpinfo->startup_cost,
+								   fpinfo->total_cost,
+								   NIL, /* no pathkeys */
+								   NULL,                /* no outer rel either */
+								   NULL,                /* no extra plan */
+								   NIL,                 /* no fdw_restrictinfo list */
+								   NIL);                /* no fdw_private list */
 #else
 	path = create_foreignscan_path(root, baserel, NULL,
 								   fpinfo->rows,
+								   0,                   /* no disabled plan nodes */
 								   fpinfo->startup_cost,
 								   fpinfo->total_cost,
 								   NIL, /* no pathkeys */
@@ -2703,10 +2719,22 @@ void tdsGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntable
 										 NULL,
 										 NULL,
 										 NIL));
+#elif PG_VERSION_NUM < 180000
+				 create_foreignscan_path(root, baserel,
+										 NULL,
+										 rows,
+										 startup_cost,
+										 total_cost,
+										 usable_pathkeys,
+										 NULL,
+										 NULL,
+										 NIL,
+										 NIL));
 #else
 				 create_foreignscan_path(root, baserel,
 										 NULL,
 										 rows,
+										 0,
 										 startup_cost,
 										 total_cost,
 										 usable_pathkeys,
@@ -2905,10 +2933,22 @@ void tdsGetForeignPaths(PlannerInfo *root, RelOptInfo *baserel, Oid foreigntable
 									   param_info->ppi_req_outer,
 									   NULL,
 									   NIL);	/* no fdw_private list */
+#elif PG_VERSION_NUM < 180000
+		path = create_foreignscan_path(root, baserel,
+									   NULL,
+									   rows,
+									   startup_cost,
+									   total_cost,
+									   NIL,		/* no pathkeys */
+									   param_info->ppi_req_outer,
+									   NULL,
+									   NIL,		/* no fdw_restrictinfo list */
+									   NIL);	/* no fdw_private list */
 #else
 		path = create_foreignscan_path(root, baserel,
 									   NULL,
 									   rows,
+									   0,		/* no disabled plan nodes */
 									   startup_cost,
 									   total_cost,
 									   NIL,		/* no pathkeys */


### PR DESCRIPTION
This commit copes with upstream commit 8123e91f5 with pathkey changes, ExplainState relocations in c65bc2e1d, and the disabled nodes parameter in e222534679.

This should resolve https://github.com/tds-fdw/tds_fdw/issues/384

It's mostly the same as the patch referenced in-thread but converted to use preprocessor defs to stay backward compatible as is done in the code already.