### PR TITLE
Release 2.0.5 to prepare for PostgreSQL 18

### DIFF
--- a/InstallAlpine.md
+++ b/InstallAlpine.md
@@ -51,7 +51,7 @@ apk add postgresql-dev
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 apk add wget
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz

--- a/InstallDebian.md
+++ b/InstallDebian.md
@@ -45,7 +45,7 @@ sudo apt-get install postgresql-11 postgresql-client-11 postgresql-server-dev-11
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 sudo apt-get install wget
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz

--- a/InstallOSX.md
+++ b/InstallOSX.md
@@ -36,7 +36,7 @@ Or use Postgres.app: <http://postgresapp.com/>
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz
 cd tds_fdw-${TDS_FDW_VERSION}

--- a/InstallRHELandClones.md
+++ b/InstallRHELandClones.md
@@ -78,7 +78,7 @@ sudo yum install centos-release-scl
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz
 cd tds_fdw-${TDS_FDW_VERSION}

--- a/InstallUbuntu.md
+++ b/InstallUbuntu.md
@@ -45,7 +45,7 @@ sudo apt-get install postgresql-11 postgresql-client-11 postgresql-server-dev-11
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 sudo apt-get install wget
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz

--- a/InstallopenSUSE.md
+++ b/InstallopenSUSE.md
@@ -40,7 +40,7 @@ sudo zypper install postgresql10 postgresql10-server postgresql10-devel
 If you'd like to use one of the release packages, you can download and install them via something like the following:
 
 ```bash
-export TDS_FDW_VERSION="2.0.4"
+export TDS_FDW_VERSION="2.0.5"
 wget https://github.com/tds-fdw/tds_fdw/archive/v${TDS_FDW_VERSION}.tar.gz
 tar -xvzf v${TDS_FDW_VERSION}.tar.gz
 cd tds_fdw-${TDS_FDW_VERSION}/

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
 	"name": "tds_fdw",
 	"abstract": "TDS Foreign data wrapper",
 	"description": "This library contains a single PostgreSQL extension, a foreign data wrapper called \"tds_fdw\". It can be used to communicate with Microsoft SQL Server and Sybase databases.",
-	"version": "2.0.4",
+	"version": "2.0.5",
 	"maintainer": [
 		"Geoff Montee <geoff.montee@gmail.com>"
 	],
@@ -19,7 +19,7 @@
 			"abstract": "TDS Foreign data wrapper",
 			"file": "sql/tds_fdw.sql",
 			"docfile": "README.md",
-			"version": "2.0.4"
+			"version": "2.0.5"
 	}
 	},
 	"resources": {

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ EXTVERSION = $(shell grep default_version $(EXTENSION).control | sed -e "s/defau
 
 DOCS         = README.${EXTENSION}.md
 
-DATA = tds_fdw--2.0.1--2.0.2.sql tds_fdw--2.0.2--2.0.3.sql tds_fdw--2.0.3--2.0.4.sql sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = tds_fdw--2.0.1--2.0.2.sql tds_fdw--2.0.2--2.0.3.sql tds_fdw--2.0.3--2.0.4.sql tds_fdw--2.0.4--2.0.5.sql sql/$(EXTENSION)--$(EXTVERSION).sql
 
 PG_CONFIG    = pg_config
 

--- a/tds_fdw--2.0.4--2.0.5.sql
+++ b/tds_fdw--2.0.4--2.0.5.sql
@@ -1,0 +1,2 @@
+-- complain if script is sourced in psql, rather than via ALTER EXTENSION
+\echo Use "ALTER EXTENSION tds_fdw UPDATE TO '2.0.5'" to load this file. \quit

--- a/tds_fdw.control
+++ b/tds_fdw.control
@@ -16,6 +16,6 @@
 #----------------------------------------------------------------------------
 
 comment = 'Foreign data wrapper for querying a TDS database (Sybase or Microsoft SQL Server)'
-default_version = '2.0.4'
+default_version = '2.0.5'
 module_pathname = '$libdir/tds_fdw'
 relocatable = true


### PR DESCRIPTION
A new release for PostgreSQL 18 was requested via: https://github.com/tds-fdw/tds_fdw/issues/384